### PR TITLE
buildpackages: import from ceph/master

### DIFF
--- a/teuthology/task/buildpackages/Makefile
+++ b/teuthology/task/buildpackages/Makefile
@@ -1,0 +1,81 @@
+SHELL=/bin/bash
+D=/tmp/stampsdir
+VPATH=${D}
+TIMEOUT_SERVER_CREATE = 30m
+TIMEOUT_BUILD = 220m # 20 minutes short of 4 hours
+PKG_REPO=packages-repository
+PKG_REPO_OS_TYPE=ubuntu
+PKG_REPO_OS_VERSION=14.04
+PKG_REPO_USER_DATA=${PKG_REPO_OS_TYPE}-${PKG_REPO_OS_VERSION}-user-data.txt
+
+# We want to extract the first listed IPv4 address!
+# Openstack will provide the addresses field in this format:
+# "net1-name=ip(, ip)+(; net2-name=ip(, ip)+)+"
+# Each IP may be v4 or v6 (including shortened forms and IPv4-mapped-IPv6 forms)
+# 1.2.3.4
+# 2001:db8:6050:ed4d:f816:3eff:fe48:3b36
+# 2001:db8::fe48:3b36
+# 2001:db8::1.2.3.4
+# Example long-form input:
+# private-network=10.10.10.69, 2001:db8:6050:ed4d:f816:3eff:fed1:d9f8;net-name2=2001:db8::fe48:3b36, 2001:db8::1.2.3.4, 1.2.3.4;
+# TODO: allow selection of the network instead of taking the first network
+# TODO: Support IPv6 in future
+define get_ip
+$$(openstack server show -f value -c addresses $(1) |perl -pe 's/^[^=]+=([^;]+).*/\1/g; s/[ ,]/\n/g; ' |grep -v -e ':' -e '^$$' |head -n1)
+endef
+
+MY_IP=$(shell hostname -I | cut -f1 -d' ')
+
+${HOME}/.ssh_agent:
+	ssh-agent -s > ${HOME}/.ssh_agent
+	source ${HOME}/.ssh_agent ; ssh-add ; ssh-add -l
+	grep -q ssh_agent ~/.bashrc_teuthology || echo 'source ${HOME}/.ssh_agent' >> ~/.bashrc_teuthology
+
+flock-${PKG_REPO}:
+	timeout $(TIMEOUT_SERVER_CREATE) openstack server create --image 'teuthology-ubuntu-14.04-${HTTP_ARCH}' ${OPENSTACK_NETWORK} --flavor ${HTTP_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${PKG_REPO_USER_DATA} --wait ${PKG_REPO}
+	sleep 30
+	set -ex ; \
+	ip=$(call get_ip,${PKG_REPO}) ; \
+	for delay in 1 2 4 8 8 8 8 8 8 8 8 8 16 16 16 16 16 32 32 32 64 128 256 512 ; do if ssh -o 'ConnectTimeout=3' $$ip bash -c '"grep -q READYTORUN /var/log/cloud-init*.log"' ; then break ; else sleep $$delay ; fi ; done ; \
+	ssh $$ip sudo apt-get update ; \
+	ssh $$ip sudo apt-get install -y nginx rsync && \
+	ssh $$ip sudo chown -R ubuntu /usr/share/nginx/html && \
+	ssh $$ip sudo rm /usr/share/nginx/html/\* && \
+	ssh $$ip sudo perl -pi -e '"s|location / {|location / { autoindex on;|"' /etc/nginx/sites-available/default && \
+	ssh $$ip sudo /etc/init.d/nginx restart && \
+	perl -pi -e "s/^gitbuilder_host:.*/gitbuilder_host: $$ip/" ~/.teuthology.yaml
+	touch ${D}/$@
+
+${PKG_REPO}:
+	mkdir -p ${D}
+	flock --close ${D}/flock-$@.lock ${MAKE} flock-$@
+	touch ${D}/$@
+
+# Just because 'server create' return success does not mean it actually succeeded!
+# Check the server status before we proceed.
+# If it's a weird status, bail out and let the delete fire
+# eg: ERROR status can happen if there is no VM host without enough capacity for the request.
+ceph-${CEPH_PKG_TYPE}-${CEPH_DIST}-${CEPH_ARCH}-${CEPH_FLAVOR}-${CEPH_SHA1}: ${PKG_REPO}
+	timeout $(TIMEOUT_SERVER_CREATE) openstack server create --image 'teuthology-${CEPH_OS_TYPE}-${CEPH_OS_VERSION}-${CEPH_ARCH}' ${OPENSTACK_NETWORK} --flavor ${BUILD_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${CEPH_OS_TYPE}-${CEPH_OS_VERSION}-user-data.txt --wait $@
+	set -ex ; \
+	trap "openstack server delete --wait $@" EXIT ; \
+	for delay in 30 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 ; do \
+		status=$$(openstack server show -c status -f value $@) ; \
+		case $$status in \
+			ACTIVE) break ;; \
+			NOSTATE|*BUILD|*BOOT|*RESIZE) sleep $$delay ;; \
+			*) exit 1 ;; \
+		esac ; \
+	done ; \
+	ip=$(call get_ip,$@) ; \
+	test -n "$$ip" || exit ; \
+	for delay in 1 2 4 8 8 8 8 8 8 8 8 8 16 16 16 16 16 32 32 32 64 128 256 512 ; do if ssh -o 'ConnectTimeout=3' $$ip bash -c '"grep -q READYTORUN /var/log/cloud-init*.log"' ; then break ; else sleep $$delay ; fi ; done ; \
+	scp make-${CEPH_PKG_TYPE}.sh common.sh ubuntu@$$ip: ; \
+	packages_repository=$(call get_ip,${<F}) ; \
+	timeout $(TIMEOUT_BUILD) ssh -tt -A ubuntu@$$ip bash ./make-${CEPH_PKG_TYPE}.sh $$packages_repository ${CEPH_DIST} ${CEPH_GIT_URL} ${CEPH_SHA1} ${CEPH_FLAVOR} ${CEPH_ARCH}
+	mkdir -p ${D}/${@D} ; touch ${D}/$@
+
+clobber:
+	pkill ssh-agent || true
+	rm -f ${HOME}/.ssh_agent
+	rm -fr ${D}

--- a/teuthology/task/buildpackages/centos-6.5-user-data.txt
+++ b/teuthology/task/buildpackages/centos-6.5-user-data.txt
@@ -1,0 +1,15 @@
+#cloud-config
+bootcmd:
+ - yum install -y yum-utils && yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/6/x86_64/ && yum install --nogpgcheck -y epel-release && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6 && rm /etc/yum.repos.d/dl.fedoraproject.org*
+ - ( echo ; echo "MaxSessions 1000" ) >> /etc/ssh/sshd_config
+ - ( echo 'Defaults !requiretty' ; echo 'Defaults visiblepw' ) | tee /etc/sudoers.d/cephlab_sudo
+preserve_hostname: true
+system_info:
+  default_user:
+    name: ubuntu
+packages:
+ - dracut-modules-growroot
+runcmd:
+ - mkinitrd --force /boot/initramfs-2.6.32-573.3.1.el6.x86_64.img 2.6.32-573.3.1.el6.x86_64
+ - reboot
+final_message: "READYTORUN"

--- a/teuthology/task/buildpackages/centos-7.0-user-data.txt
+++ b/teuthology/task/buildpackages/centos-7.0-user-data.txt
@@ -1,0 +1,1 @@
+user-data.txt

--- a/teuthology/task/buildpackages/centos-7.1-user-data.txt
+++ b/teuthology/task/buildpackages/centos-7.1-user-data.txt
@@ -1,0 +1,1 @@
+user-data.txt

--- a/teuthology/task/buildpackages/centos-7.2-user-data.txt
+++ b/teuthology/task/buildpackages/centos-7.2-user-data.txt
@@ -1,0 +1,1 @@
+user-data.txt

--- a/teuthology/task/buildpackages/common.sh
+++ b/teuthology/task/buildpackages/common.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 Red Hat <contact@redhat.com>
+#
+# Author: Loic Dachary <loic@dachary.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+function install_deps() {
+    git archive --remote=git://git.ceph.com/ceph.git master install-deps.sh | tar -xvf -
+    #
+    # drop the following hack when trusty is not supported anymore
+    # there is no other way as long as we maintain a debian directory that tries
+    # to be the same for all distributions
+    #
+    if grep --quiet 14.04 /etc/issue 2>/dev/null && sudo apt-get install --force-yes -qq -y dpkg-dev && test "$(dpkg-architecture -qDEB_BUILD_GNU_CPU 2>/dev/null)" = aarch64 ; then
+        sed -i -e '/libgoogle-perftools-dev/d' debian/control
+    fi
+    bash -x install-deps.sh
+}
+
+function git_submodules() {
+    # see http://tracker.ceph.com/issues/13426
+    perl -pi -e 's|git://ceph.com/git/ceph-object-corpus.git|https://github.com/ceph/ceph-object-corpus.git|' .gitmodules
+    local force=$(if git submodule usage 2>&1 | grep --quiet 'update.*--force'; then echo --force ; fi)
+    git submodule sync || return 1
+    git submodule update $force --init --recursive || return 1
+}
+
+function get_ceph() {
+    local git_ceph_url=$1
+    local sha1=$2
+
+    test -d ceph || git clone ${git_ceph_url} ceph
+    cd ceph
+    if test -d src ; then # so we don't try to fetch when using a fixture
+       git fetch --tags http://github.com/ceph/ceph
+    fi
+    git fetch --tags ${git_ceph_url}
+    git checkout ${sha1}
+}
+
+function init_ceph() {
+    local git_ceph_url=$1
+    local sha1=$2
+    get_ceph $git_ceph_url $sha1 || return 1
+    git_submodules || return 1
+    install_deps || return 1
+}
+
+function flavor2configure() {
+    local flavor=$1
+
+    eval $(dpkg-architecture)
+
+    if test $flavor = notcmalloc || test "$DEB_HOST_GNU_CPU" = aarch64 ; then
+        echo --without-tcmalloc --without-cryptopp
+    fi
+}
+
+#
+# for a given $sha1 in the $ceph_dir repository, lookup all references
+# from the remote origin and tags matching the sha1. Add a symbolic
+# link in $ref_dir to the $sha1 for each reference found. If the
+# reference is a tag, also add a symbolic link to the commit to which
+# the tag points, if it is an annotated tag.
+#
+function link_same() {
+    local ref_dir=$1
+    local ceph_dir=$2
+    local sha1=$3
+
+    mkdir -p $ref_dir
+    (
+        cd ${ceph_dir}
+        git for-each-ref refs/tags/** refs/remotes/origin/** | grep $sha1 | \
+            while read sha1 type ref ; do
+                if test $type = 'tag' ; then
+                    commit_sha1=$(git rev-parse $ref^{commit})
+                    if test $commit_sha1 != $sha1 ; then
+                        echo ../sha1/$sha1 ../sha1/$commit_sha1
+                    fi
+                fi
+                echo ../sha1/$sha1 $(basename $ref)
+            done
+    ) | while read from to ; do
+        ( cd $ref_dir ; ln -sf $from $to )
+    done
+}
+
+function test_link_same() {
+    local d=/tmp/link_same$$
+    mkdir -p $d/primary
+    cd $d/primary
+    git init
+    touch a ; git add a ; git commit -m 'm' a
+    git tag tag1
+    tag1=$(git rev-parse HEAD)
+    git branch branch1
+    touch b ; git add b ; git commit -m 'm' b
+    git tag --annotate -m 'a' tag2
+    tag2=$(git rev-parse tag2)
+    sha1_tag2=$(git rev-parse tag2^{commit})
+    git branch branch2
+    touch c ; git add c ; git commit -m 'm' c
+    git branch branch3
+    sha1_branch3=$(git rev-parse branch3)
+
+    git clone $d/primary $d/secondary
+    cd $d/secondary
+    mkdir $d/ref $d/sha1
+
+    touch $d/sha1/$sha1_branch3
+    link_same $d/ref $d/secondary $sha1_branch3
+    test $(readlink --canonicalize $d/ref/branch3) = $d/sha1/$sha1_branch3 || return 1
+    test $(readlink --canonicalize $d/ref/master) = $d/sha1/$sha1_branch3 || return 1
+
+    touch $d/sha1/$tag2
+    link_same $d/ref $d/secondary $tag2
+    test $(readlink --canonicalize $d/ref/tag2) = $d/sha1/$tag2 || return 1
+    test $(readlink --canonicalize $d/sha1/$sha1_tag2) = $d/sha1/$tag2 || return 1
+
+    touch $d/sha1/$tag1
+    link_same $d/ref $d/secondary $tag1
+    test $(readlink --canonicalize $d/ref/tag1) = $d/sha1/$tag1 || return 1
+    test $(readlink --canonicalize $d/ref/branch1) = $d/sha1/$tag1 || return 1
+
+    rm -fr $d
+}
+
+function maybe_parallel() {
+    local nproc=$1
+    local vers=$2
+
+    if echo $vers | grep --quiet '0\.67' ; then
+        return
+    fi
+
+    if test $nproc -gt 1 ; then
+        echo -j${nproc}
+    fi
+}
+
+function test_maybe_parallel() {
+    test "$(maybe_parallel 1 0.72)" = "" || return 1
+    test "$(maybe_parallel 8 0.67)" = "" || return 1
+    test "$(maybe_parallel 8 0.72)" = "-j8" || return 1
+}
+
+if test "$1" = "TEST" ; then
+    shopt -s -o xtrace
+    PS4='${BASH_SOURCE[0]}:$LINENO: ${FUNCNAME[0]}:  '
+    test_link_same
+    test_maybe_parallel
+fi

--- a/teuthology/task/buildpackages/debian-8.0-user-data.txt
+++ b/teuthology/task/buildpackages/debian-8.0-user-data.txt
@@ -1,0 +1,12 @@
+#cloud-config
+bootcmd:
+ - echo 'APT::Get::AllowUnauthenticated "true";' | tee /etc/apt/apt.conf.d/99disablesigs
+ - echo nameserver 8.8.8.8 | tee -a /etc/resolv.conf # last resort, in case the DHCP server does not provide a resolver
+manage_etc_hosts: true
+preserve_hostname: true
+system_info:
+  default_user:
+    name: ubuntu
+runcmd:
+ - echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+final_message: "READYTORUN"

--- a/teuthology/task/buildpackages/make-deb.sh
+++ b/teuthology/task/buildpackages/make-deb.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 Red Hat <contact@redhat.com>
+#
+# Author: Loic Dachary <loic@dachary.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+
+# 
+# Create and upload a deb repository with the same naming conventions
+# as https://github.com/ceph/autobuild-ceph/blob/master/build-ceph-deb.sh
+#
+set -xe
+
+base=/tmp/release
+gitbuilder_host=$1
+codename=$2
+git_ceph_url=$3
+sha1=$4
+flavor=$5
+arch=$6
+
+sudo apt-get update
+sudo apt-get install -y git
+
+source $(dirname $0)/common.sh
+
+init_ceph $git_ceph_url $sha1
+
+#codename=$(lsb_release -sc)
+releasedir=$base/$(lsb_release -si)/WORKDIR
+#
+# git describe provides a version that is
+# a) human readable
+# b) is unique for each commit
+# c) compares higher than any previous commit
+# d) contains the short hash of the commit
+#
+vers=$(git describe --match "v*" | sed s/^v//)
+#
+# always set the debian version to 1 which is ok because the debian
+# directory is included in the sources and the upstream version will
+# change each time it is modified.
+#
+dvers="$vers-1"
+: ${NPROC:=$(nproc)}
+ceph_dir=$(pwd)
+
+function build_package() {
+
+    rm -fr $releasedir
+    mkdir -p $releasedir
+    #
+    # remove all files not under git so they are not
+    # included in the distribution.
+    #
+    git clean -qdxff
+
+    fileext="gz"
+    # autotools only works in jewel and below
+    if [[ ! -e "make-dist" ]] ; then
+        #
+        # creating the distribution tarbal requires some configure
+        # options (otherwise parts of the source tree will be left out).
+        #
+        ./autogen.sh
+        # Building with LTTNG on Ubuntu Precise is not possible.
+        # It fails the LTTNG-is-sane check (it misses headers)
+        # And the Debian rules files leave it out anyway
+        case $codename in
+	    precise) lttng_opt="--without-lttng" ;;
+	    *) lttng_opt="--with-lttng" ;;
+        esac
+        ./configure $(flavor2configure $flavor) \
+            --with-rocksdb --with-ocf \
+            --with-nss --with-debug --enable-cephfs-java \
+            $lttng_opt --with-babeltrace
+        #
+        # use distdir= to set the name of the top level directory of the
+        # tarbal to match the desired version
+        #
+        make distdir=ceph-$vers dist
+    else
+      ./make-dist
+      fileext="bz2"
+    fi
+    #
+    # rename the tarbal to match debian conventions and extract it
+    #
+    mv ceph-$vers.tar.$fileext $releasedir/ceph_$vers.orig.tar.$fileext
+    tar -C $releasedir -xf $releasedir/ceph_$vers.orig.tar.$fileext
+    #
+    # copy the debian directory over
+    #
+    cp -a debian $releasedir/ceph-$vers/debian
+    cd $releasedir
+    #
+    # uncomment to remove -dbg packages
+    # because they are large and take time to build
+    #
+    #perl -ni -e 'print if(!(/^Package: .*-dbg$/../^$/))' ceph-$vers/debian/control
+    #perl -pi -e 's/--dbg-package.*//' ceph-$vers/debian/rules
+    #
+    # update the changelog to match the desired version
+    #
+    cd ceph-$vers
+    local chvers=$(head -1 debian/changelog | perl -ne 's/.*\(//; s/\).*//; print')
+    if [ "$chvers" != "$dvers" ]; then
+        DEBEMAIL="contact@ceph.com" dch -D $codename --force-distribution -b -v "$dvers" "new version"
+    fi
+    #
+    # create the packages (with ccache)
+    #
+    export CEPH_EXTRA_CONFIGURE_ARGS=$(flavor2configure $flavor)
+    j=$(maybe_parallel $NPROC $vers)
+    PATH=/usr/lib/ccache:$PATH dpkg-buildpackage $j -uc -us -sa
+}
+
+function build_repo() {
+    local gitbuilder_host=$1
+
+    sudo apt-get install -y reprepro
+    cd ${releasedir}/..
+    #
+    # Create a repository in a directory with a name structured
+    # as
+    #
+    base=ceph-deb-$codename-$arch-$flavor
+    sha1_dir=$codename/$base/sha1/$sha1
+    mkdir -p $sha1_dir/conf
+    cat > $sha1_dir/conf/distributions <<EOF
+Codename: $codename
+Suite: stable
+Components: main
+Architectures: i386 amd64 arm64 source
+EOF
+    reprepro --basedir $sha1_dir include $codename WORKDIR/*.changes
+    echo $dvers > $sha1_dir/version
+    echo $sha1 > $sha1_dir/sha1
+    link_same $codename/$base/ref $ceph_dir $sha1
+    if test "$gitbuilder_host" ; then
+        cd $codename
+        sudo apt-get install -y rsync
+        RSYNC_RSH='ssh -o StrictHostKeyChecking=false' rsync -av $base/ $gitbuilder_host:/usr/share/nginx/html/$base/
+    fi
+}
+
+build_package
+build_repo $gitbuilder_host

--- a/teuthology/task/buildpackages/make-rpm.sh
+++ b/teuthology/task/buildpackages/make-rpm.sh
@@ -1,0 +1,279 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 Red Hat <contact@redhat.com>
+#
+# Author: Loic Dachary <loic@dachary.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+
+# 
+# Create and upload a RPM repository with the same naming conventions
+# as https://github.com/ceph/autobuild-ceph/blob/master/build-ceph-rpm.sh
+#
+
+set -xe
+
+base=/tmp/release
+gitbuilder_host=$1
+codename=$2
+git_ceph_url=$3
+sha1=$4
+flavor=$5
+arch=$6
+
+suse=false
+[[ $codename =~ suse ]] && suse=true
+
+if [ "$suse" = true ] ; then
+    sudo zypper -n install git
+else
+    sudo yum install -y git
+fi
+
+source $(dirname $0)/common.sh
+
+init_ceph $git_ceph_url $sha1
+
+distro=$( source /etc/os-release ; echo $ID )
+distro_version=$( source /etc/os-release ; echo $VERSION )
+releasedir=$base/$distro/WORKDIR
+#
+# git describe provides a version that is
+# a) human readable
+# b) is unique for each commit
+# c) compares higher than any previous commit
+# d) contains the short hash of the commit
+#
+vers=$(git describe --match "v*" | sed s/^v//)
+ceph_dir=$(pwd)
+
+#
+# Create a repository in a directory with a name structured
+# as
+#
+base=ceph-rpm-$codename-$arch-$flavor
+
+function setup_rpmmacros() {
+    if ! grep -q find_debuginfo_dwz_opts $HOME/.rpmmacros ; then
+        echo '%_find_debuginfo_dwz_opts %{nil}' >> $HOME/.rpmmacros
+    fi
+    if [ "x${distro}x" = "xcentosx" ] && echo $distro_version | grep -q '7' ; then
+        if ! grep -q '%dist .el7' $HOME/.rpmmacros ; then
+            echo '%dist .el7' >> $HOME/.rpmmacros
+        fi
+    fi
+}
+
+function build_package() {
+    rm -fr $releasedir
+    mkdir -p $releasedir
+    #
+    # remove all files not under git so they are not
+    # included in the distribution.
+    #
+    git clean -qdxff
+    #
+    # creating the distribution tarbal requires some configure
+    # options (otherwise parts of the source tree will be left out).
+    #
+    if [ "$suse" = true ] ; then
+        sudo zypper -n install bzip2
+    else
+        sudo yum install -y bzip2
+    fi
+    # autotools only works in jewel and below
+    if [[ ! -e "make-dist" ]] ; then
+        ./autogen.sh
+        ./configure $(flavor2configure $flavor) --with-debug --with-radosgw --with-fuse --with-libatomic-ops --with-gtk2 --with-nss
+
+        #
+        # use distdir= to set the name of the top level directory of the
+        # tarbal to match the desired version
+        #
+        make dist-bzip2
+    else
+        # kraken and above
+        ./make-dist
+    fi
+    # Set up build area
+    setup_rpmmacros
+    if [ "$suse" = true ] ; then
+        sudo zypper -n install rpm-build
+    else
+        sudo yum install -y rpm-build
+    fi
+    local buildarea=$releasedir
+    mkdir -p ${buildarea}/SOURCES
+    mkdir -p ${buildarea}/SRPMS
+    mkdir -p ${buildarea}/SPECS
+    cp ceph.spec ${buildarea}/SPECS
+    mkdir -p ${buildarea}/RPMS
+    mkdir -p ${buildarea}/BUILD
+    CEPH_TARBALL=( ceph-*.tar.bz2 )
+    cp -a $CEPH_TARBALL ${buildarea}/SOURCES/.
+    cp -a rpm/*.patch ${buildarea}/SOURCES || true
+    (
+        cd ${buildarea}/SPECS
+        ccache=$(echo /usr/lib*/ccache)
+        # Build RPMs
+        if [ "$suse" = true ]; then
+          sed -i -e '0,/%package/s//%debug_package\n&/' \
+                 -e 's/%{epoch}://g' \
+                 -e '/^Epoch:/d' \
+                 -e 's/%bcond_with ceph_test_package/%bcond_without ceph_test_package/' \
+                 -e "s/^Source0:.*$/Source0: $CEPH_TARBALL/" \
+                 ceph.spec
+        fi
+        buildarea=`readlink -fn ${releasedir}`   ### rpm wants absolute path
+        PATH=$ccache:$PATH rpmbuild -ba --define "_unpackaged_files_terminate_build 0" --define "_topdir ${buildarea}" ceph.spec
+    )
+}
+
+function build_rpm_release() {
+    local buildarea=$1
+    local sha1=$2
+    local gitbuilder_host=$3
+    local base=$4
+
+    cat <<EOF > ${buildarea}/SPECS/ceph-release.spec
+Name:           ceph-release
+Version:        1
+Release:        0%{?dist}
+Summary:        Ceph repository configuration
+Group:          System Environment/Base
+License:        GPLv2
+URL:            http://gitbuilder.ceph.com/$dist
+Source0:        ceph.repo
+#Source0:        RPM-GPG-KEY-CEPH
+#Source1:        ceph.repo
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildArch:	noarch
+
+%description
+This package contains the Ceph repository GPG key as well as configuration
+for yum and up2date.
+
+%prep
+
+%setup -q  -c -T
+install -pm 644 %{SOURCE0} .
+#install -pm 644 %{SOURCE1} .
+
+%build
+
+%install
+rm -rf %{buildroot}
+#install -Dpm 644 %{SOURCE0} \
+#    %{buildroot}/%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-CEPH
+%if 0%{defined suse_version}
+install -dm 755 %{buildroot}/%{_sysconfdir}/zypp
+install -dm 755 %{buildroot}/%{_sysconfdir}/zypp/repos.d
+install -pm 644 %{SOURCE0} \
+    %{buildroot}/%{_sysconfdir}/zypp/repos.d
+%else
+install -dm 755 %{buildroot}/%{_sysconfdir}/yum.repos.d
+install -pm 644 %{SOURCE0} \
+    %{buildroot}/%{_sysconfdir}/yum.repos.d
+%endif
+
+%clean
+#rm -rf %{buildroot}
+
+%post
+
+%postun
+
+%files
+%defattr(-,root,root,-)
+#%doc GPL
+%if 0%{defined suse_version}
+/etc/zypp/repos.d/*
+%else
+/etc/yum.repos.d/*
+%endif
+#/etc/pki/rpm-gpg/*
+
+%changelog
+* Tue Mar 10 2013 Gary Lowell <glowell@inktank.com> - 1-0
+- Handle both yum and zypper
+- Use URL to ceph git repo for key
+- remove config attribute from repo file
+* Tue Aug 27 2012 Gary Lowell <glowell@inktank.com> - 1-0
+- Initial Package
+EOF
+
+    cat <<EOF > $buildarea/SOURCES/ceph.repo
+[Ceph]
+name=Ceph packages for \$basearch
+baseurl=http://${gitbuilder_host}/${base}/sha1/${sha1}/\$basearch
+enabled=1
+gpgcheck=0
+type=rpm-md
+
+[Ceph-noarch]
+name=Ceph noarch packages
+baseurl=http://${gitbuilder_host}/${base}/sha1/${sha1}/noarch
+enabled=1
+gpgcheck=0
+type=rpm-md
+
+[ceph-source]
+name=Ceph source packages
+baseurl=http://${gitbuilder_host}/${base}/sha1/${sha1}/SRPMS
+enabled=1
+gpgcheck=0
+type=rpm-md
+EOF
+
+    rpmbuild -bb --define "_topdir ${buildarea}" ${buildarea}/SPECS/ceph-release.spec
+}
+
+function build_rpm_repo() {
+    local buildarea=$1
+    local gitbuilder_host=$2
+    local base=$3
+
+    if [ "$suse" = true ] ; then
+        sudo zypper -n install createrepo
+    else
+        sudo yum install -y createrepo
+    fi
+
+    for dir in ${buildarea}/SRPMS ${buildarea}/RPMS/*
+    do
+        createrepo ${dir}
+    done
+
+    local sha1_dir=${buildarea}/../$codename/$base/sha1/$sha1
+    mkdir -p $sha1_dir
+    echo $vers > $sha1_dir/version
+    echo $sha1 > $sha1_dir/sha1
+    echo ceph > $sha1_dir/name
+
+    for dir in ${buildarea}/SRPMS ${buildarea}/RPMS/*
+    do
+        cp -fla ${dir} $sha1_dir
+    done
+
+    link_same ${buildarea}/../$codename/$base/ref $ceph_dir $sha1
+    if test "$gitbuilder_host" ; then
+        (
+            cd ${buildarea}/../$codename
+            RSYNC_RSH='ssh -o StrictHostKeyChecking=false' rsync -av $base/ ubuntu@$gitbuilder_host:/usr/share/nginx/html/$base/
+        )
+    fi
+}
+
+setup_rpmmacros
+build_package
+build_rpm_release $releasedir $sha1 $gitbuilder_host $base
+build_rpm_repo $releasedir $gitbuilder_host $base

--- a/teuthology/task/buildpackages/opensuse-42.1-user-data.txt
+++ b/teuthology/task/buildpackages/opensuse-42.1-user-data.txt
@@ -1,0 +1,13 @@
+#cloud-config
+bootcmd:
+ - echo nameserver 8.8.8.8 | tee -a /etc/resolv.conf # last resort, in case the DHCP server does not provide a resolver
+manage_etc_hosts: true
+preserve_hostname: true
+users:
+  - name: ubuntu
+    gecos: User
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    groups: users
+runcmd:
+ - ( MYHOME=/home/ubuntu ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /root/.ssh/authorized_keys $MYHOME/.ssh ; chown -R ubuntu.users $MYHOME/.ssh )
+final_message: "READYTORUN"

--- a/teuthology/task/buildpackages/sle-12.1-user-data.txt
+++ b/teuthology/task/buildpackages/sle-12.1-user-data.txt
@@ -1,0 +1,15 @@
+#cloud-config
+bootcmd:
+ - echo nameserver 8.8.8.8 | tee -a /etc/resolv.conf # last resort, in case the DHCP server does not provide a resolver
+ - SUSEConnect -p sle-sdk/12.2/x86_64
+manage_etc_hosts: true
+preserve_hostname: true
+users:
+  - name: ubuntu
+    gecos: User
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    groups: users
+runcmd:
+ - ( MYHOME=/home/ubuntu ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /root/.ssh/authorized_keys $MYHOME/.ssh ; chown -R ubuntu.users $MYHOME/.ssh )
+ - zypper --non-interactive install --no-recommends python wget git ntp rsyslog lsb-release
+final_message: "READYTORUN"

--- a/teuthology/task/buildpackages/sle-12.2-user-data.txt
+++ b/teuthology/task/buildpackages/sle-12.2-user-data.txt
@@ -1,0 +1,15 @@
+#cloud-config
+bootcmd:
+ - echo nameserver 8.8.8.8 | tee -a /etc/resolv.conf # last resort, in case the DHCP server does not provide a resolver
+ - SUSEConnect -p sle-sdk/12.2/x86_64
+manage_etc_hosts: true
+preserve_hostname: true
+users:
+  - name: ubuntu
+    gecos: User
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    groups: users
+runcmd:
+ - ( MYHOME=/home/ubuntu ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /root/.ssh/authorized_keys $MYHOME/.ssh ; chown -R ubuntu.users $MYHOME/.ssh )
+ - zypper --non-interactive install --no-recommends python wget git ntp rsyslog lsb-release
+final_message: "READYTORUN"

--- a/teuthology/task/buildpackages/ubuntu-12.04-user-data.txt
+++ b/teuthology/task/buildpackages/ubuntu-12.04-user-data.txt
@@ -1,0 +1,1 @@
+user-data.txt

--- a/teuthology/task/buildpackages/ubuntu-14.04-user-data.txt
+++ b/teuthology/task/buildpackages/ubuntu-14.04-user-data.txt
@@ -1,0 +1,1 @@
+user-data.txt

--- a/teuthology/task/buildpackages/ubuntu-16.04-user-data.txt
+++ b/teuthology/task/buildpackages/ubuntu-16.04-user-data.txt
@@ -1,0 +1,1 @@
+user-data.txt

--- a/teuthology/task/buildpackages/user-data.txt
+++ b/teuthology/task/buildpackages/user-data.txt
@@ -1,0 +1,10 @@
+#cloud-config
+bootcmd:
+ - echo 'APT::Get::AllowUnauthenticated "true";' | tee /etc/apt/apt.conf.d/99disablesigs
+ - echo nameserver 8.8.8.8 | tee -a /etc/resolv.conf # last resort, in case the DHCP server does not provide a resolver
+manage_etc_hosts: true
+preserve_hostname: true
+system_info:
+  default_user:
+    name: ubuntu
+final_message: "READYTORUN"


### PR DESCRIPTION
It is exactly the same in all branches. It really belongs in teuthology
and was placed in ceph-qa-suite because it required a more flexible
development cycle.

Signed-off-by: Loic Dachary <loic@dachary.org>