### PR TITLE
openstack: buildpackages is gitbuilder compatible

### DIFF
--- a/teuthology/openstack/setup-openstack.sh
+++ b/teuthology/openstack/setup-openstack.sh
@@ -50,6 +50,7 @@ function create_config() {
 
     cat > ~/.teuthology.yaml <<EOF
 $archive_upload
+use_shaman: false
 archive_upload_key: teuthology/openstack/archive-key
 lock_server: http://localhost:8080/
 results_server: http://localhost:8080/


### PR DESCRIPTION
Do not use shaman (it is the new default).

Signed-off-by: Loic Dachary <ldachary@redhat.com>