### PR TITLE
dnsmasq must respond to all requests

### DIFF
--- a/teuthology/openstack/setup-openstack.sh
+++ b/teuthology/openstack/setup-openstack.sh
@@ -375,6 +375,9 @@ function setup_dnsmasq() {
     local dev=$2
 
     if ! test -f /etc/dnsmasq.d/resolv ; then
+        # FIXME: this opens up dnsmasq to DNS reflection/amplification attacks, and can be reverted
+        # FIXME: once we figure out how to configure dnsmasq to accept DNS queries from all subnets
+        sudo perl -pi -e 's/--local-service//' /etc/init.d/dnsmasq
         resolver=$(grep nameserver /etc/resolv.conf | head -1 | perl -ne 'print $1 if(/\s*nameserver\s+([\d\.]+)/)')
         sudo apt-get -qq install -y --force-yes dnsmasq resolvconf
         echo resolv-file=/etc/dnsmasq-resolv.conf | sudo tee /etc/dnsmasq.d/resolv


### PR DESCRIPTION
It is a security issue that should be addressed when running long lived
clusters. But teuthology-openstack is meant to not last more than a few
days.

Signed-off-by: Loic Dachary <ldachary@redhat.com>