### PR TITLE
setup: do not set ceph_qa_suite_git_url in ~/.teuthology.yaml

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -653,14 +653,13 @@ class TeuthologyOpenStack(OpenStack):
         if self.args.upload:
             argv.extend(['--archive-upload', self.args.archive_upload,
                          '--archive-upload-url', self.args.archive_upload_url])
-        for (arg, opt) in (('ceph_repo', 'ceph_git_url'),
-                           ('suite_repo', 'ceph_qa_suite_git_url')):
-            if getattr(self.args, arg):
-                command = (
-                    "perl -pi -e 's|.*{opt}.*|{opt}: {value}|'"
-                    " ~/.teuthology.yaml"
-                ).format(opt=opt, value=getattr(self.args, arg))
-                self.ssh(command)
+        ceph_repo = getattr(self.args, 'ceph_repo')
+        if ceph_repo:
+            command = (
+                "perl -pi -e 's|.*{opt}.*|{opt}: {value}|'"
+                " ~/.teuthology.yaml"
+            ).format(opt='ceph_git_url', value=ceph_repo)
+            self.ssh(command)
         argv.append('/home/' + self.username +
                     '/teuthology/teuthology/openstack/openstack.yaml')
         command = (

--- a/teuthology/openstack/setup-openstack.sh
+++ b/teuthology/openstack/setup-openstack.sh
@@ -57,7 +57,6 @@ results_server: http://localhost:8080/
 gitbuilder_host: gitbuilder.ceph.com
 check_package_signatures: false
 ceph_git_url: https://github.com/ceph/ceph.git
-ceph_qa_suite_git_url: https://github.com/ceph/ceph.git
 queue_port: 11300
 suite_verify_ceph_hash: false
 queue_host: localhost

--- a/teuthology/task/buildpackages/make-rpm.sh
+++ b/teuthology/task/buildpackages/make-rpm.sh
@@ -52,9 +52,18 @@ releasedir=$base/$distro/WORKDIR
 # a) human readable
 # b) is unique for each commit
 # c) compares higher than any previous commit
+#    WAIT, c) DOES NOT HOLD:
+#    >>> print 'v10.2.5-7-g000000' < 'v10.2.5-8-g000000'
+#    True
+#    >>> print 'v10.2.5-9-g000000' < 'v10.2.5-10-g000000'
+#    False
 # d) contains the short hash of the commit
 #
-vers=$(git describe --match "v*" | sed s/^v//)
+# Regardless, we use it for the RPM version number, but strip the leading 'v'
+# and replace the '-' before the 'g000000' with a '.' to match the output of
+# "rpm -q $PKG --qf %{VERSION}-%{RELEASE}"
+#
+vers=$(git describe --match "v*" | sed -r -e 's/^v//' -e 's/\-([[:digit:]]+)\-g/\-\1\.g/')
 ceph_dir=$(pwd)
 
 #


### PR DESCRIPTION
When this value is set, it is necessary to explicitly give --suite-repo and
--suite-branch. We would rather have the defaults for these come from
--ceph-repo and --ceph.

Signed-off-by: Nathan Cutler <ncutler@suse.com>