### PR TITLE
clock: use ntpq instead of ntpdc

### DIFF
--- a/teuthology/nuke/actions.py
+++ b/teuthology/nuke/actions.py
@@ -385,7 +385,7 @@ def synch_clocks(remotes):
             args=[
                 'sudo', 'service', 'ntp', 'stop',
                 run.Raw('&&'),
-                'sudo', 'ntpdate-debian',
+                'sudo', 'ntpd', '-gq',
                 run.Raw('&&'),
                 'sudo', 'hwclock', '--systohc', '--utc',
                 run.Raw('&&'),

--- a/teuthology/openstack/openstack-opensuse-42.1-user-data.txt
+++ b/teuthology/openstack/openstack-opensuse-42.1-user-data.txt
@@ -17,4 +17,7 @@ users:
 runcmd:
  - ( MYHOME=/home/{username} ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /root/.ssh/authorized_keys $MYHOME/.ssh ; chown -R {username}.users $MYHOME/.ssh )
  - zypper --non-interactive install --no-recommends python wget git ntp rsyslog lsb-release
+ - ( if ! grep '^server' /etc/ntp.conf ; then for i in 0 1 2 3 ; do echo "server $i.opensuse.pool.ntp.org iburst" >> /etc/ntp.conf ; done ; fi )
+ - systemctl enable ntpd.service
+ - systemctl restart ntpd.service
 final_message: "{up}, after $UPTIME seconds"

--- a/teuthology/openstack/openstack-sle-12.2-user-data.txt
+++ b/teuthology/openstack/openstack-sle-12.2-user-data.txt
@@ -19,4 +19,7 @@ users:
 runcmd:
  - ( MYHOME=/home/{username} ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /root/.ssh/authorized_keys $MYHOME/.ssh ; chown -R {username}.users $MYHOME/.ssh )
  - zypper --non-interactive install --no-recommends python wget git ntp rsyslog lsb-release
+ - ( if ! grep '^server' /etc/ntp.conf ; then for i in 0 1 2 3 ; do echo "server $i.opensuse.pool.ntp.org iburst" >> /etc/ntp.conf ; done ; fi )
+ - systemctl enable ntpd.service
+ - systemctl start ntpd.service
 final_message: "{up}, after $UPTIME seconds"

--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -230,9 +230,20 @@ def get_initial_tasks(lock, config, machine_type):
     init_tasks.append({'internal.timer': None})
 
     if 'roles' in config:
+        if machine_type != 'openstack':
+            init_tasks.extend([
+                {'pcp': None},
+            ])
+        if ('os_type' in config):
+            os_type = config['os_type']
+        else:
+            os_type = 'unknown'
+        log.info("os_type is {}".format(os_type))
+        if os_type == 'centos':
+            init_tasks.extend([
+                {'selinux': None},
+            ])
         init_tasks.extend([
-            {'pcp': None},
-            {'selinux': None},
             {'ansible.cephlab': None},
             {'clock.check': None}
         ])

--- a/teuthology/task/clock.py
+++ b/teuthology/task/clock.py
@@ -52,7 +52,7 @@ def task(ctx, config):
             'service', 'ntp', 'start',
             run.Raw(';'),
             'PATH=/usr/bin:/usr/sbin',
-            'ntpdc', '-p',
+            'ntpq', '-p',
         ])
         rem.run(args)
 
@@ -65,7 +65,7 @@ def task(ctx, config):
             rem.run(
                 args=[
                     'PATH=/usr/bin:/usr/sbin',
-                    'ntpdc', '-p',
+                    'ntpq', '-p',
                     ],
                 )
 
@@ -73,7 +73,7 @@ def task(ctx, config):
 @contextlib.contextmanager
 def check(ctx, config):
     """
-    Run ntpdc at the start and the end of the task.
+    Run ntpq at the start and the end of the task.
 
     :param ctx: Context
     :param config: Configuration
@@ -83,7 +83,7 @@ def check(ctx, config):
         rem.run(
             args=[
                 'PATH=/usr/bin:/usr/sbin',
-                'ntpdc', '-p',
+                'ntpq', '-p',
                 ],
             )
 
@@ -96,6 +96,6 @@ def check(ctx, config):
             rem.run(
                 args=[
                     'PATH=/usr/bin:/usr/sbin',
-                    'ntpdc', '-p',
+                    'ntpq', '-p',
                     ],
                 )


### PR DESCRIPTION
Newer versions of ntpd have ntpdc support turned off by default,
to avoid NTP reflection/amplification.

See, e.g., https://mail-index.netbsd.org/netbsd-users/2015/08/04/msg016612.html

Signed-off-by: Nathan Cutler <ncutler@suse.com>