### PR TITLE
user-data: tweak Ubuntu 16.04 user-data

### DIFF
--- a/teuthology/openstack/openstack-centos-6.5-user-data.txt
+++ b/teuthology/openstack/openstack-centos-6.5-user-data.txt
@@ -2,7 +2,7 @@
 bootcmd:
  - echo nameserver {nameserver} | tee /etc/resolv.conf
  - echo search {lab_domain} | tee -a /etc/resolv.conf
- - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-eth0
+ - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-*
  - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - yum install -y yum-utils && yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/6/x86_64/ && yum install --nogpgcheck -y epel-release && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6 && rm /etc/yum.repos.d/dl.fedoraproject.org*

--- a/teuthology/openstack/openstack-centos-6.5-user-data.txt
+++ b/teuthology/openstack/openstack-centos-6.5-user-data.txt
@@ -2,7 +2,7 @@
 bootcmd:
  - echo nameserver {nameserver} | tee /etc/resolv.conf
  - echo search {lab_domain} | tee -a /etc/resolv.conf
- - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-*
+ - sed -i -e 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-*
  - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - yum install -y yum-utils && yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/6/x86_64/ && yum install --nogpgcheck -y epel-release && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6 && rm /etc/yum.repos.d/dl.fedoraproject.org*

--- a/teuthology/openstack/openstack-centos-7.0-user-data.txt
+++ b/teuthology/openstack/openstack-centos-7.0-user-data.txt
@@ -2,7 +2,7 @@
 bootcmd:
  - echo nameserver {nameserver} | tee /etc/resolv.conf
  - echo search {lab_domain} | tee -a /etc/resolv.conf
- - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-eth0
+ - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-*
  - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - ( echo ; echo "MaxSessions 1000" ) >> /etc/ssh/sshd_config

--- a/teuthology/openstack/openstack-centos-7.0-user-data.txt
+++ b/teuthology/openstack/openstack-centos-7.0-user-data.txt
@@ -2,7 +2,7 @@
 bootcmd:
  - echo nameserver {nameserver} | tee /etc/resolv.conf
  - echo search {lab_domain} | tee -a /etc/resolv.conf
- - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-*
+ - sed -i -e 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-*
  - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - ( echo ; echo "MaxSessions 1000" ) >> /etc/ssh/sshd_config

--- a/teuthology/openstack/openstack-centos-7.1-user-data.txt
+++ b/teuthology/openstack/openstack-centos-7.1-user-data.txt
@@ -2,7 +2,7 @@
 bootcmd:
  - echo nameserver {nameserver} | tee /etc/resolv.conf
  - echo search {lab_domain} | tee -a /etc/resolv.conf
- - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-eth0
+ - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-*
  - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - ( echo ; echo "MaxSessions 1000" ) >> /etc/ssh/sshd_config

--- a/teuthology/openstack/openstack-centos-7.1-user-data.txt
+++ b/teuthology/openstack/openstack-centos-7.1-user-data.txt
@@ -2,7 +2,7 @@
 bootcmd:
  - echo nameserver {nameserver} | tee /etc/resolv.conf
  - echo search {lab_domain} | tee -a /etc/resolv.conf
- - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-*
+ - sed -i -e 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-*
  - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - ( echo ; echo "MaxSessions 1000" ) >> /etc/ssh/sshd_config

--- a/teuthology/openstack/openstack-centos-7.2-user-data.txt
+++ b/teuthology/openstack/openstack-centos-7.2-user-data.txt
@@ -2,7 +2,7 @@
 bootcmd:
  - echo nameserver {nameserver} | tee /etc/resolv.conf
  - echo search {lab_domain} | tee -a /etc/resolv.conf
- - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-eth0
+ - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-*
  - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - ( echo ; echo "MaxSessions 1000" ) >> /etc/ssh/sshd_config

--- a/teuthology/openstack/openstack-centos-7.2-user-data.txt
+++ b/teuthology/openstack/openstack-centos-7.2-user-data.txt
@@ -2,7 +2,7 @@
 bootcmd:
  - echo nameserver {nameserver} | tee /etc/resolv.conf
  - echo search {lab_domain} | tee -a /etc/resolv.conf
- - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-*
+ - sed -i -e 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-*
  - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - ( echo ; echo "MaxSessions 1000" ) >> /etc/ssh/sshd_config

--- a/teuthology/openstack/openstack-debian-8.0-user-data.txt
+++ b/teuthology/openstack/openstack-debian-8.0-user-data.txt
@@ -1,10 +1,10 @@
 #cloud-config
 bootcmd:
  - apt-get remove --purge -y resolvconf || true
- - echo 'prepend domain-name-servers {nameserver};' | sudo tee -a /etc/dhcp/dhclient.conf
- - echo 'supersede domain-name "{lab_domain}";' | sudo tee -a /etc/dhcp/dhclient.conf
- - ifdown eth0 ; ifup eth0
- - grep --quiet {nameserver} /etc/resolv.conf || ( echo 'nameserver {nameserver}' ; echo 'search {lab_domain}' ) | sudo tee /etc/resolv.conf
+ - echo 'prepend domain-name-servers {nameserver};' | tee -a /etc/dhcp/dhclient.conf
+ - echo 'supersede domain-name "{lab_domain}";' | tee -a /etc/dhcp/dhclient.conf
+ - ifdown -a ; ifup -a
+ - grep --quiet {nameserver} /etc/resolv.conf || ( echo 'nameserver {nameserver}' ; echo 'search {lab_domain}' ) | tee /etc/resolv.conf
  - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - echo "MaxSessions 1000" >> /etc/ssh/sshd_config

--- a/teuthology/openstack/openstack-opensuse-42.1-user-data.txt
+++ b/teuthology/openstack/openstack-opensuse-42.1-user-data.txt
@@ -2,7 +2,7 @@
 bootcmd:
  - echo nameserver {nameserver} | tee /etc/resolv.conf
  - echo search {lab_domain} | tee -a /etc/resolv.conf
- - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network/ifcfg-eth0
+ - sed -i -e 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network/ifcfg-eth0
  - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - ( echo ; echo "MaxSessions 1000" ) >> /etc/ssh/sshd_config

--- a/teuthology/openstack/openstack-sle-12.2-user-data.txt
+++ b/teuthology/openstack/openstack-sle-12.2-user-data.txt
@@ -2,7 +2,7 @@
 bootcmd:
  - echo nameserver {nameserver} | tee /etc/resolv.conf
  - echo search {lab_domain} | tee -a /etc/resolv.conf
- - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network/ifcfg-eth0
+ - sed -i -e 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network/ifcfg-eth0
  - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - ( echo ; echo "MaxSessions 1000" ) >> /etc/ssh/sshd_config

--- a/teuthology/openstack/openstack-ubuntu-12.04-user-data.txt
+++ b/teuthology/openstack/openstack-ubuntu-12.04-user-data.txt
@@ -1,10 +1,10 @@
 #cloud-config
 bootcmd:
  - apt-get remove --purge -y resolvconf || true
- - echo 'prepend domain-name-servers {nameserver};' | sudo tee -a /etc/dhcp/dhclient.conf
- - echo 'supersede domain-name "{lab_domain}";' | sudo tee -a /etc/dhcp/dhclient.conf
- - ifdown eth0 ; ifup eth0
- - grep --quiet {nameserver} /etc/resolv.conf || ( echo 'nameserver {nameserver}' ; echo 'search {lab_domain}' ) | sudo tee /etc/resolv.conf
+ - echo 'prepend domain-name-servers {nameserver};' | tee -a /etc/dhcp/dhclient.conf
+ - echo 'supersede domain-name "{lab_domain}";' | tee -a /etc/dhcp/dhclient.conf
+ - ifdown -a ; ifup -a
+ - grep --quiet {nameserver} /etc/resolv.conf || ( echo 'nameserver {nameserver}' ; echo 'search {lab_domain}' ) | tee /etc/resolv.conf
  - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - echo "MaxSessions 1000" >> /etc/ssh/sshd_config

--- a/teuthology/openstack/openstack-ubuntu-14.04-user-data.txt
+++ b/teuthology/openstack/openstack-ubuntu-14.04-user-data.txt
@@ -1,10 +1,10 @@
 #cloud-config
 bootcmd:
  - apt-get remove --purge -y resolvconf || true
- - echo 'prepend domain-name-servers {nameserver};' | sudo tee -a /etc/dhcp/dhclient.conf
- - echo 'supersede domain-name "{lab_domain}";' | sudo tee -a /etc/dhcp/dhclient.conf
- - ifdown eth0 ; ifup eth0
- - grep --quiet {nameserver} /etc/resolv.conf || ( echo 'nameserver {nameserver}' ; echo 'search {lab_domain}' ) | sudo tee /etc/resolv.conf
+ - echo 'prepend domain-name-servers {nameserver};' | tee -a /etc/dhcp/dhclient.conf
+ - echo 'supersede domain-name "{lab_domain}";' | tee -a /etc/dhcp/dhclient.conf
+ - ifdown -a ; ifup -a
+ - grep --quiet {nameserver} /etc/resolv.conf || ( echo 'nameserver {nameserver}' ; echo 'search {lab_domain}' ) | tee /etc/resolv.conf
  - ( wget -qO - http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(wget -qO - http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - echo "MaxSessions 1000" >> /etc/ssh/sshd_config

--- a/teuthology/openstack/openstack-ubuntu-16.04-user-data.txt
+++ b/teuthology/openstack/openstack-ubuntu-16.04-user-data.txt
@@ -3,8 +3,7 @@ bootcmd:
  - apt-get remove --purge -y resolvconf || true
  - echo 'prepend domain-name-servers {nameserver};' | tee -a /etc/dhcp/dhclient.conf
  - echo 'supersede domain-name "{lab_domain}";' | tee -a /etc/dhcp/dhclient.conf
- - ifdown eth0 ; ifup eth0
- - ifdown ens3 ; ifup ens3
+ - ifdown -a ; ifup -a
  - grep --quiet {nameserver} /etc/resolv.conf || ( echo 'nameserver {nameserver}' ; echo 'search {lab_domain}' ) | tee /etc/resolv.conf
  - ( wget -qO - http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(wget -qO - http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)

--- a/teuthology/openstack/openstack-ubuntu-16.04-user-data.txt
+++ b/teuthology/openstack/openstack-ubuntu-16.04-user-data.txt
@@ -1,1 +1,22 @@
-openstack-ubuntu-14.04-user-data.txt
+#cloud-config
+bootcmd:
+ - apt-get remove --purge -y resolvconf || true
+ - echo 'prepend domain-name-servers {nameserver};' | tee -a /etc/dhcp/dhclient.conf
+ - echo 'supersede domain-name "{lab_domain}";' | tee -a /etc/dhcp/dhclient.conf
+ - ifdown eth0 ; ifup eth0
+ - ifdown ens3 ; ifup ens3
+ - grep --quiet {nameserver} /etc/resolv.conf || ( echo 'nameserver {nameserver}' ; echo 'search {lab_domain}' ) | tee /etc/resolv.conf
+ - ( wget -qO - http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(wget -qO - http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
+ - hostname $(cat /etc/hostname)
+ - echo "MaxSessions 1000" >> /etc/ssh/sshd_config
+manage_etc_hosts: true
+preserve_hostname: true
+system_info:
+  default_user:
+    name: {username}
+packages:
+ - python
+ - wget
+ - git
+ - ntp
+final_message: "{up}, after $UPTIME seconds"

--- a/teuthology/openstack/openstack-user-data.txt
+++ b/teuthology/openstack/openstack-user-data.txt
@@ -1,7 +1,7 @@
 #cloud-config
 bootcmd:
   - touch /tmp/init.out
-  - echo nameserver 8.8.8.8 | sudo tee -a /etc/resolv.conf # last resort, in case the DHCP server does not provide a resolver
+  - echo nameserver 8.8.8.8 | tee -a /etc/resolv.conf # last resort, in case the DHCP server does not provide a resolver
 manage_etc_hosts: true
 system_info:
   default_user:

--- a/teuthology/task/buildpackages.py
+++ b/teuthology/task/buildpackages.py
@@ -28,7 +28,7 @@ class LocalGitbuilderProject(packaging.GitbuilderProject):
 
 
 def get_pkg_type(os_type):
-    if os_type in ('centos', 'fedora', 'opensuse', 'rhel', 'sles'):
+    if os_type in ('centos', 'fedora', 'opensuse', 'rhel', 'sle'):
         return 'rpm'
     else:
         return 'deb'


### PR DESCRIPTION
With this tweak, Ubuntu 16.04 VMs come up with

```
ubuntu@target137074030173:~$ cat /etc/resolv.conf
domain teuthology
search teuthology
nameserver 137.74.29.118
nameserver 213.186.33.99
```

Do you know how to prevent the second nameserver line from being added?