### PR TITLE
buildpackages: fix make-rpm.sh for kraken + SUSE

### DIFF
--- a/teuthology/task/buildpackages/make-rpm.sh
+++ b/teuthology/task/buildpackages/make-rpm.sh
@@ -114,6 +114,10 @@ function build_package() {
         make dist-bzip2
     else
         # kraken and above
+        if [ "$suse" = true ]; then
+            sed -i -e 's/^%autosetup -p1$/%autosetup -p1 -n @TARBALL_BASENAME@/' \
+                ceph.spec.in
+        fi
         ./make-dist
     fi
     # Set up build area


### PR DESCRIPTION
make-rpm.sh breaks for kraken when run on SLE-12-SP2:

```
+ rpmbuild -ba --define '_unpackaged_files_terminate_build 0' --define '_topdir /tmp/release/sles/WORKDIR' ceph.spec
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.F2hJfx
+ umask 022
+ cd /tmp/release/sles/WORKDIR/BUILD
+ cd /tmp/release/sles/WORKDIR/BUILD
+ rm -rf ceph-11.1.0
+ /usr/bin/bzip2 -dc /tmp/release/sles/WORKDIR/SOURCES/ceph-11.1.0-7423-g8f37fcc.tar.bz2
+ /bin/tar -xf -
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd ceph-11.1.0
/var/tmp/rpm-tmp.F2hJfx: line 35: cd: ceph-11.1.0: No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp.F2hJfx (%prep)
```

EDIT: After pursuing a number of dead ends, I found the root cause. The buildpackages task uses `make-dist` to generate the tarball. In order for the tarball so generated to be buildable by rpmbuild, the spec file must contain the following lines:

```
Version:        @VERSION@
Release:        @RPM_RELEASE@%{?dist}
...
%prep
%autosetup -p1 -n @TARBALL_BASENAME@
```

SUSE builds in OBS/IBS use a modified spec file and uses a different mechanism to generate the tarball. (This worked well up until jewel but for kraken and beyond we may need to reconsider.) In the SUSE downstream version of the spec file, the lines look like this:

```
Version:        @VERSION@
Release:        @RPM_RELEASE@%{?dist}
...
%prep
%if 0%{?rhel}
%autosetup -p1 -n @TARBALL_BASENAME@
%endif
%if ! 0%{?rhel}
%autosetup -p1
%endif
```

The absence of `-n @TARBALL_BASENAME@` causes the tarball basename to be `ceph-$VERSION` (e.g. ceph-12.0.0) instead of the full `ceph-$VERSION-$RPM_RELEASE` (e.g. ceph-12.0.0-3534.g000000), yet rpmbuild expects the latter because the `Release:` field of the spec file is populated.