### PR TITLE
buildpackages: add centos-7.3-user-data.txt

### DIFF
--- a/teuthology/task/buildpackages/centos-7.3-user-data.txt
+++ b/teuthology/task/buildpackages/centos-7.3-user-data.txt
@@ -1,0 +1,1 @@
+user-data.txt


### PR DESCRIPTION
Tests are failing with:

2017-02-18T11:07:34.742 DEBUG:teuthology.misc:timeout 30m openstack server create --image 'teuthology-centos-7.3-x86_64'  --flavor hg-60-ssd --key-name teuthology --security-group teuthology --property ownedby=149.202.169.26 --user-data centos-7.3-user-data.txt --wait ceph-rpm-centos7-x86_64-basic-f65754e312f11823c5bb7e9fe24655f3fd68bcd2
2017-02-18T11:07:37.227 DEBUG:teuthology.misc:Can't open 'centos-7.3-user-data.txt': [Errno 2] No such file or directory: 'centos-7.3-user-data.txt'

Signed-off-by: Nathan Cutler <ncutler@suse.com>