### PR TITLE
tests: fix test_create

### DIFF
--- a/teuthology/openstack/test/test_openstack.py
+++ b/teuthology/openstack/test/test_openstack.py
@@ -1667,7 +1667,7 @@ openstack keypair delete {key_name} || true
         assert 0 == teuthology.ssh("lsb_release -a")
         assert 0 == teuthology.ssh("grep 'substituded variables' /var/log/cloud-init.log")
         l = caplog.text()
-        assert 'Ubuntu 14.04' in l
+        assert 'Ubuntu 16.04' in l
         assert "nworkers=" + str(args.simultaneous_jobs) in l
         assert "username=" + teuthology.username in l
         assert "upload=--archive-upload user@archive:/tmp" in l


### PR DESCRIPTION
```
>       assert 'Ubuntu 14.04' in l
E       assert 'Ubuntu 14.04' in '...
__init__.py                732 INFO     Distributor ID: Ubuntu
__init__.py                732 INFO     Description:    Ubuntu 16.04.1 LTS
__init__.py                732 INFO     Release:        16.04
__init__.py                732 INFO     Codename:       xenial
transport.py              1567 DEBUG    EOF in transport thread'
```

(This isn't exactly what the error message said, but close enough.)
