### PR TITLE
doc: add sudo to pkill and explain how to run a single test

### DIFF
--- a/docs/openstack_backend.rst
+++ b/docs/openstack_backend.rst
@@ -131,6 +131,10 @@ test. Login wih the ssh access displayed at the end of the
 
     $ sudo pkill -f teuthology-worker
     $ cd teuthology ; pip install "tox>=1.9"
+
+There are two test suites, ``openstack-integration.py`` and ``openstack.py``.
+To run them, do the following::
+
     $ tox -v -e openstack-integration
     integration/openstack-integration.py::TestSuite::test_suite_noop PASSED
     ...
@@ -139,6 +143,15 @@ test. Login wih the ssh access displayed at the end of the
     integration/test_openstack.py::TestTeuthologyOpenStack::test_create PASSED
     ...
     ========= 1 passed in 204.35 seconds =========
+
+To run a single test::
+
+    $ tox -v -e py27-integration -- teuthology/openstack/test/openstack-integration.py::TestSuite::test_suite_noop
+
+The same, but with messages in real time::
+
+    $ tox -v -e py27-integration -- -s -v teuthology/openstack/test/openstack-integration.py::TestSuite::test_suite_noop
+
 
 Defining instances flavor and volumes
 -------------------------------------

--- a/docs/openstack_backend.rst
+++ b/docs/openstack_backend.rst
@@ -129,7 +129,7 @@ This will create a virtual machine suitable for the integration
 test. Login wih the ssh access displayed at the end of the
 ``teuthology-openstack`` command and run the following::
 
-    $ pkill -f teuthology-worker
+    $ sudo pkill -f teuthology-worker
     $ cd teuthology ; pip install "tox>=1.9"
     $ tox -v -e openstack-integration
     integration/openstack-integration.py::TestSuite::test_suite_noop PASSED


### PR DESCRIPTION
Without sudo:

(virtualenv) ubuntu@teuthology:~$ pkill -f teuthology-worker
pkill: killing pid 6735 failed: Operation not permitted
pkill: killing pid 6736 failed: Operation not permitted
pkill: killing pid 6737 failed: Operation not permitted
pkill: killing pid 6738 failed: Operation not permitted
pkill: killing pid 6739 failed: Operation not permitted
pkill: killing pid 6740 failed: Operation not permitted
pkill: killing pid 6741 failed: Operation not permitted
pkill: killing pid 6742 failed: Operation not permitted
pkill: killing pid 6743 failed: Operation not permitted
pkill: killing pid 6744 failed: Operation not permitted

With sudo, it just works.

Signed-off-by: Nathan Cutler <ncutler@suse.com>