### PR TITLE
Refactor salt class to be reusable

### DIFF
--- a/teuthology/openstack/openstack-opensuse-42.1-user-data.txt
+++ b/teuthology/openstack/openstack-opensuse-42.1-user-data.txt
@@ -9,7 +9,7 @@ bootcmd:
 # See https://github.com/ceph/ceph-cm-ansible/blob/master/roles/cobbler/templates/snippets/cephlab_user
  - ( echo 'Defaults !requiretty' ; echo 'Defaults visiblepw' ) | tee /etc/sudoers.d/cephlab_sudo ; chmod 0440 /etc/sudoers.d/cephlab_sudo
 preserve_hostname: true
-users: 
+users:
   - name: {username}
     gecos: User
     sudo: ["ALL=(ALL) NOPASSWD:ALL"]
@@ -17,8 +17,9 @@ users:
 runcmd:
  - ( MYHOME=/home/{username} ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /root/.ssh/authorized_keys $MYHOME/.ssh ; chown -R {username}.users $MYHOME/.ssh )
  - zypper --non-interactive --no-gpg-checks refresh
- - zypper --non-interactive install --no-recommends python wget git ntp rsyslog lsb-release salt-minion
- - sed -i -e "s/^#master:.*$/master:\ $(curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//')$(eval printf "%03d%03d%03d%03d.{lab_domain}" $(echo "{nameserver}" | tr . ' '))/" /etc/salt/minion 
+ - zypper --non-interactive install --no-recommends python wget git ntp rsyslog
+   lsb-release salt-minion salt-master make
+ - sed -i -e "s/^#master:.*$/master:\ $(curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//')$(eval printf "%03d%03d%03d%03d.{lab_domain}" $(echo "{nameserver}" | tr . ' '))/" /etc/salt/minion
  - ( if ! grep '^server' /etc/ntp.conf ; then for i in 0 1 2 3 ; do echo "server $i.opensuse.pool.ntp.org iburst" >> /etc/ntp.conf ; done ; fi )
  - systemctl enable salt-minion.service ntpd.service
  - systemctl restart ntpd.service

--- a/teuthology/openstack/openstack-sle-12.2-user-data.txt
+++ b/teuthology/openstack/openstack-sle-12.2-user-data.txt
@@ -19,8 +19,10 @@ users:
 runcmd:
  - ( MYHOME=/home/{username} ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /root/.ssh/authorized_keys $MYHOME/.ssh ; chown -R {username}.users $MYHOME/.ssh )
  - zypper --non-interactive --no-gpg-checks refresh
- - zypper --non-interactive install --no-recommends python wget git ntp rsyslog lsb-release
+ - zypper --non-interactive install --no-recommends python wget git ntp rsyslog
+   lsb-release salt-minion salt-master make
+ - sed -i -e "s/^#master:.*$/master:\ $(curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//')$(eval printf "%03d%03d%03d%03d.{lab_domain}" $(echo "{nameserver}" | tr . ' '))/" /etc/salt/minion
  - ( if ! grep '^server' /etc/ntp.conf ; then for i in 0 1 2 3 ; do echo "server $i.opensuse.pool.ntp.org iburst" >> /etc/ntp.conf ; done ; fi )
- - systemctl enable ntpd.service
- - systemctl start ntpd.service
+ - systemctl enable salt-minion.service ntpd.service
+ - systemctl restart ntpd.service
 final_message: "{up}, after $UPTIME seconds"

--- a/teuthology/salt.py
+++ b/teuthology/salt.py
@@ -2,12 +2,13 @@ import logging
 import re
 import time
 
-from os.path import isfile
+from cStringIO import StringIO
 from netifaces import ifaddresses
 
 import teuthology
 from .contextutil import safe_while
 from .misc import sh
+from .orchestra.remote import Remote
 from .orchestra import run
 
 log = logging.getLogger(__name__)
@@ -30,7 +31,7 @@ class UseSalt(object):
         return False
 
     def use_salt(self):
-        #if self.openstack() and self.suse():
+        # if self.openstack() and self.suse():
         #    return True
         return False
 
@@ -42,66 +43,99 @@ class Salt(object):
         self.job_id = ctx.config.get('job_id')
         self.cluster = ctx.cluster
         self.remotes = ctx.cluster.remotes
-        # FIXME: this seems fragile (ens3 hardcoded)
-        self.teuthology_ip_address = ifaddresses('ens3')[2][0]['addr']
         self.minions = []
-        ip_addr = self.teuthology_ip_address.split('.')
-        self.teuthology_fqdn = "target{:03d}{:03d}{:03d}{:03d}.teuthology".format(
+        # FIXME: this seems fragile (ens3 hardcoded)
+        teuthology_ip_address = ifaddresses('ens3')[2][0]['addr']
+        ip_addr = teuthology_ip_address.split('.')
+        teuthology_remote_name = "ubuntu@target{:03d}{:03d}{:03d}{:03d}.teuthology".format(
             int(ip_addr[0]),
             int(ip_addr[1]),
             int(ip_addr[2]),
             int(ip_addr[3]),
         )
-        self.master_fqdn = kwargs.get('master_fqdn', self.teuthology_fqdn)
+        if(not config):
+            self.master_remote = Remote(teuthology_remote_name)
+        else:
+            self.master_remote = Remote(config.get('master_remote',
+                    teuthology_remote_name))
+        log.debug("master_remote is {}".format(self.master_remote))
 
-    def generate_minion_keys(self):
+        self.__generate_minion_keys()
+        self.__preseed_minions()
+        self.__set_minion_master()
+        self.__start_master()
+        self.__start_minions()
+
+    def __generate_minion_keys(self):
+        '''
+        Generate minion key on salt master to be used to preseed this cluster's
+        minions.
+        '''
         for rem in self.remotes.iterkeys():
-            minion_id=rem.shortname
+            minion_id = rem.shortname
             self.minions.append(minion_id)
-            log.debug("minion: ID {sn}".format(
-                sn=minion_id,
-            ))
+            log.debug("minion: ID {}".format(minion_id,))
             # mode 777 is necessary to be able to generate keys reliably
             # we hit this before: https://github.com/saltstack/salt/issues/31565
-            self.master_remote.run(args = ['mkdir', 'salt'],
-                    check_status = False)
-            self.master_remote.run(args = ['mkdir', '-m', '777', 'salt/minion-keys'],
-                    check_status = False)
-            self.master_remote.run(args = ['sudo', 'salt-key',
-                '--gen-keys={sn}'.format(sn=minion_id),
-                '--gen-keys-dir=salt/minion-keys/'])
+            self.master_remote.run(args = [
+                'sudo',
+                'sh',
+                '-c',
+                'if [ ! -d salt ]; then\
+                mkdir -m 777 salt; fi'])
+            self.master_remote.run(args = [
+                'sudo',
+                'sh',
+                '-c',
+                'if [ ! -d salt/minion-keys ]; then\
+                mkdir -m 777 salt/minion-keys; fi'])
+            self.master_remote.run(args = [
+                'sudo',
+                'sh',
+                '-c',
+                'if [ ! -f salt/minion-keys/{mid}.pem ]; then\
+                salt-key --gen-keys={mid}\
+                --gen-keys-dir=salt/minion-keys/; fi'.format(mid = minion_id)])
 
-    def cleanup_keys(self):
+    def __cleanup_keys(self):
+        '''
+        Remove this cluster's minion keys (files and accepted keys)
+        '''
         for rem in self.remotes.iterkeys():
-            minion_fqdn=rem.name.split('@')[1]
-            minion_id=rem.shortname
-            log.debug("Deleting minion key: FQDN {fqdn}, ID {sn}".format(
-                fqdn=minion_fqdn,
-                sn=minion_id,
-            ))
-            sh('sudo salt-key -y -d {sn}'.format(sn=minion_id))
+            minion_id = rem.shortname
+            log.debug("Deleting minion key: ID {}".format(minion_id))
+            self.master_remote.run(args = ['sudo', 'salt-key', '-y', '-d',
+                '{}'.format(minion_id)])
+            self.master_remote.run(args = ['sudo', 'rm',
+                'salt/minion-keys/{}.pem'.format(minion_id),
+                'salt/minion-keys/{}.pub'.format(minion_id)])
 
-    def preseed_minions(self):
+    def __preseed_minions(self):
+        '''
+        Preseed minions with generated and accepted keys, as well as the job_id
+        grain and the minion id (the remotes shortname)
+        '''
         for rem in self.remotes.iterkeys():
-            minion_fqdn=rem.name.split('@')[1]
-            minion_id=rem.shortname
+            minion_id = rem.shortname
             self.master_remote.run(args = ['sudo', 'cp',
-                'salt/minion-keys/{sn}.pub'.format(sn=minion_id),
-                '/etc/salt/pki/master/minions/{sn}'.format(sn=minion_id)])
+                'salt/minion-keys/{}.pub'.format(minion_id),
+                '/etc/salt/pki/master/minions/{}'.format(minion_id)])
             self.master_remote.run(args = ['sudo', 'chown', 'ubuntu',
-                "salt/minion-keys/{sn}.pem".format(sn=minion_id),
-                "salt/minion-keys/{sn}.pub".format(sn=minion_id)])
+                "salt/minion-keys/{}.pem".format(minion_id),
+                "salt/minion-keys/{}.pub".format(minion_id)])
             # copy the keys via the teuthology VM. The worker VMs can't ssh to
             # each other. scp -3 does a 3-point copy through the teuhology VM.
             sh('scp -3 {}:salt/minion-keys/{}.* {}:'.format(self.master_remote.name,
                 minion_id, rem.name))
             r = rem.run(
                 args=[
+                    # add jobid to grains
                     'sudo',
 		    'sh',
                     '-c',
                     'echo "grains:" > /etc/salt/minion.d/job_id_grains.conf;\
                     echo "  job_id: {}" >> /etc/salt/minion.d/job_id_grains.conf'.format(self.job_id),
+                    # set proper owner and permissions on keys
 		    'sudo',
                     'chown',
                     'root',
@@ -112,8 +146,13 @@ class Salt(object):
                     'chmod',
                     '600',
                     '{}.pem'.format(minion_id),
+                    run.Raw(';'),
+                    'sudo',
+                    'chmod',
+                    '644',
                     '{}.pub'.format(minion_id),
                     run.Raw(';'),
+                    # move keys to correct location
                     'sudo',
                     'mv',
                     '{}.pem'.format(minion_id),
@@ -124,82 +163,67 @@ class Salt(object):
                     '{}.pub'.format(minion_id),
                     '/etc/salt/pki/minion/minion.pub',
                     run.Raw(';'),
+                    # set minion id to shortname
                     'sudo',
                     'sh',
                     '-c',
                     'echo {} > /etc/salt/minion_id'.format(minion_id),
-                    run.Raw(';'),
-                    'sudo',
-                    'cat',
-                    '/etc/salt/minion_id',
                 ],
             )
 
-    def set_minion_master(self):
+    def __set_minion_master(self):
         """Points all minions to the master"""
+        master_shortname = self.master_remote.name.split('@')[1]
         for rem in self.remotes.iterkeys():
             sed_cmd = 'echo master: {} > ' \
-                      '/etc/salt/minion.d/master.conf'.format(
-                self.master_fqdn
-            )
+                      '/etc/salt/minion.d/master.conf'.format(master_shortname)
             rem.run(args=[
+                # remove old master public key if present. Minion will refuse to
+                # start if master name changed but old key is present
                 'sudo',
                 'rm',
                 '/etc/salt/pki/minion/minion_master.pub',
                 run.Raw(';'),
+                # set master id
                 'sudo',
                 'sh',
                 '-c',
                 sed_cmd,
             ])
 
-    def init_minions(self):
-        self.generate_minion_keys()
-        self.preseed_minions()
-        self.set_minion_master()
-
-    def start_master(self):
-        """Starts salt-master.service on given FQDN via SSH"""
+    def __start_master(self):
+        """Starts salt-master.service on master_remote via SSH"""
         self.master_remote.run(args = ['sudo', 'systemctl', 'restart',
             'salt-master.service'])
 
-    def stop_minions(self):
+    def __stop_minions(self):
         """Stops salt-minion.service on all target VMs"""
-        run.wait(
-            self.cluster.run(
-                args=['sudo', 'systemctl', 'stop', 'salt-minion.service'],
-                wait=False,
-            )
-        )
+        self.cluster.run( args=['sudo', 'systemctl', 'stop',
+            'salt-minion.service'])
 
-    def start_minions(self):
+    def __start_minions(self):
         """Starts salt-minion.service on all target VMs"""
-        run.wait(
-            self.cluster.run(
-                args=['sudo', 'systemctl', 'restart', 'salt-minion.service'],
-                wait=False,
-            )
-        )
-
-    def ping_minion(self, mid):
-        """Pings a minion, raises exception if it doesn't respond"""
-        self.__ping("sudo salt '{}' test.ping".format(mid), 1)
-
-    def ping_minions(self):
-        """Pings minions with this cluser's job_id, raises exception if they don't respond"""
-        self.__ping("sudo salt -C 'G@job_id:{}' test.ping".format(self.job_id),
-                len(self.remotes))
+        self.cluster.run( args=['sudo', 'systemctl', 'restart',
+            'salt-minion.service'])
 
     def __ping(self, ping_cmd, expected):
         with safe_while(sleep=2, tries=10,
                 action=ping_cmd) as proceed:
             while proceed():
-                if self.master_fqdn == self.teuthology_fqdn:
-                    res = sh(ping_cmd)
-                    responded = len(re.findall('True', res))
-                    log.debug("{} minion(s) responded".format(responded))
-                    if(expected == responded):
-                        return
-                else:
-                    # master is a remote
-                    pass
+                output = StringIO()
+                self.master_remote.run(args = ping_cmd, stdout = output)
+                responded = len(re.findall('True', output.getvalue()))
+                log.debug("{} minion(s) responded".format(responded))
+                output.close()
+                if(expected == responded):
+                    return
+
+    def ping_minion(self, mid):
+        """Pings a minion, raises exception if it doesn't respond"""
+        self.__ping(["sudo", "salt", mid, "test.ping"], 1)
+
+    def ping_minions(self):
+        """Pings minions with this cluser's job_id, raises exception if they don't respond"""
+        self.__ping(["sudo", "salt", "-C", "G@job_id:{}".format(self.job_id),
+            "test.ping"], len(self.remotes))
+

--- a/teuthology/task/ceph_cm_salt.py
+++ b/teuthology/task/ceph_cm_salt.py
@@ -13,8 +13,6 @@ def task(ctx, config):
     """
     log.info("ceph_cm_salt: begin")
     salt = Salt(ctx, config)
-    salt.init_minions()
-    salt.start_minions()
     salt.ping_minions()
     log.info("ceph_cm_salt: end")
     #log.info("Going to sleep at the end of ceph_cm_salt task")


### PR DESCRIPTION
This enables salt to be used for initial target initialisation as well as target tests.