### PR TITLE
teuthology-openstack: -c argument for ceph branch is no longer optional

### DIFF
--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -43,7 +43,6 @@ def get_suite_parser():
     parser.add_argument(
         '-c', '--ceph',
         help='The ceph branch to run against',
-        default='master',
     )
     parser.add_argument(
         '-k', '--kernel',


### PR DESCRIPTION
This argument is no longer optional in teuthology-suite. This leads to
unexpected behaviour when teuthology-openstack is run with '-c master'.
The openstack parser swalloed this argument, since it assumed this was
the default values, leading to teuthology-suite bailing out.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>