### PR TITLE
openstack: restrict traffic from world to bare minimum

### DIFF
--- a/teuthology/provision/openstack.py
+++ b/teuthology/provision/openstack.py
@@ -136,7 +136,7 @@ class ProvisionOpenStack(OpenStack):
                " " + net +
                " --min " + str(num) +
                " --max " + str(num) +
-               " --security-group teuthology" +
+               " --security-group teuthology-worker" +
                " --property teuthology=" + self.property +
                " --property ownedby=" + config.openstack['ip'] +
                " --wait " +


### PR DESCRIPTION
The Teuthology VM only needs to open for ssh, pulpito and paddles
traffic. The worker VMs should only communicate with each other and the
Teuthology VM.
Test instance here http://158.69.92.41:8081/

Signed-off-by: Jan Fajerski <jfajerski@suse.com>

