### PR TITLE
openstack/userdata: remove package systemd-logger

### DIFF
--- a/teuthology/openstack/openstack-opensuse-42.1-user-data.txt
+++ b/teuthology/openstack/openstack-opensuse-42.1-user-data.txt
@@ -17,6 +17,7 @@ users:
 runcmd:
  - ( MYHOME=/home/{username} ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /root/.ssh/authorized_keys $MYHOME/.ssh ; chown -R {username}.users $MYHOME/.ssh )
  - zypper --non-interactive --no-gpg-checks refresh
+ - zypper --non-interactive remove systemd-logger
  - zypper --non-interactive install --no-recommends python wget git ntp rsyslog
    lsb-release salt-minion salt-master make
  - sed -i -e "s/^#master:.*$/master:\ $(curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//')$(eval printf "%03d%03d%03d%03d.{lab_domain}" $(echo "{nameserver}" | tr . ' '))/" /etc/salt/minion


### PR DESCRIPTION
In 42.2 this conflicts with rsyslog. In 42.1 the package is not
installed and the remove operation does nothing.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>