### PR TITLE
buildpackages: use install-deps.sh from local clone

### DIFF
--- a/teuthology/task/buildpackages/common.sh
+++ b/teuthology/task/buildpackages/common.sh
@@ -15,7 +15,9 @@
 # GNU Library Public License for more details.
 #
 function install_deps() {
-    git archive --remote=git://git.ceph.com/ceph.git master install-deps.sh | tar -xvf -
+    if [ ! -f install-deps.sh ]; then
+        git archive --remote=git://git.ceph.com/ceph.git master install-deps.sh | tar -xvf -
+    fi
     #
     # drop the following hack when trusty is not supported anymore
     # there is no other way as long as we maintain a debian directory that tries


### PR DESCRIPTION
Note: we are guaranteed to be in the local clone when `install_deps` (the function) is called, so `install-deps.sh` (the script) is "just there".