### PR TITLE
openstack: increase teuthology flavors

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -809,10 +809,14 @@ ssh access           : ssh {identity}{username}@{ip} # logs in /usr/share/nginx/
             'cpus': 1,
         }
         if self.args.simultaneous_jobs >= 100:
+            hint['ram'] = 60000 # MB
+        elif self.args.simultaneous_jobs >= 50:
             hint['ram'] = 30000 # MB
         elif self.args.simultaneous_jobs >= 25:
-            hint['ram'] = 8000 # MB
+            hint['ram'] = 15000 # MB
         elif self.args.simultaneous_jobs >= 10:
+            hint['ram'] = 8000 # MB
+        elif self.args.simultaneous_jobs >= 2:
             hint['ram'] = 4000 # MB
 
         select = None


### PR DESCRIPTION
Ansible has higher memory requirements these days. Keep the default
flavor to the minimum because it is used during tests.

Signed-off-by: Loic Dachary <loic@dachary.org>