### PR TITLE
task/ansible.py: tell ansible-playbook not to fork

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -316,7 +316,7 @@ class Ansible(Task):
         extra_vars = dict(ansible_ssh_user=user)
         extra_vars.update(self.config.get('vars', dict()))
         args = [
-            'ansible-playbook', '-v',
+            'ansible-playbook', '-v', '-f', '1',
             "--extra-vars", "'%s'" % json.dumps(extra_vars),
             '-i', self.inventory,
             '--limit', ','.join(fqdns),


### PR DESCRIPTION
Newer ansibles start 5 parallel processes on every invocation of
ansible-playbook. This can easily overwhelm the teuthology VM.

Signed-off-by: Nathan Cutler <ncutler@suse.com>