### PR TITLE
packaging: add ceph-rpm-under-test zypper repo with high priority

### DIFF
--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -794,7 +794,7 @@ class GitbuilderProject(object):
             url = "{base_url}/{arch}".format(
                 base_url=self.base_url, arch=self.arch)
             self.remote.run(args=[
-                'sudo', 'zypper', '-n', 'addrepo', url, 'ceph-rpm-under-test'
+                'sudo', 'zypper', '-n', 'addrepo', '-p', '1', url, 'ceph-rpm-under-test'
             ])
         else:
             self.remote.run(args=['sudo', 'yum', '-y', 'install', url])


### PR DESCRIPTION
Otherwise the ceph packages from OBS are preferred because RPM evaluates, e.g.,
12.0.2+git.1493341348.9148e53 as a higher version number than
12.0.2-276.gf27d4b00ed.

Signed-off-by: Nathan Cutler <ncutler@suse.com>