### PR TITLE
buildpackages: zypper refresh before first zypper install

### DIFF
--- a/teuthology/task/buildpackages/make-rpm.sh
+++ b/teuthology/task/buildpackages/make-rpm.sh
@@ -36,7 +36,8 @@ suse=false
 [[ $codename =~ sle ]] && suse=true
 
 if [ "$suse" = true ] ; then
-    sudo zypper -n install --no-recommends git
+    sudo zypper --non-interactive --no-gpg-checks refresh
+    sudo zypper --non-interactive install --no-recommends git
 else
     sudo yum install -y git
 fi


### PR DESCRIPTION
Refresh is needed to avoid errors like "Media source 'https://...' does not
contain the desired medium" when we use live repositories.

Signed-off-by: Nathan Cutler <ncutler@suse.com>