### PR TITLE
task: install: rpm: zypper install with --no-recommends

### DIFF
--- a/teuthology/task/install/rpm.py
+++ b/teuthology/task/install/rpm.py
@@ -127,10 +127,12 @@ def _update_package_list_and_install(ctx, remote, rpm, config):
         pkg_mng_cmd = 'zypper'
         pkg_mng_opts = '-n'
         pkg_mng_subcommand_opts = '--capability'
+        pkg_mng_install_opts = '--no-recommends'
     else:
         pkg_mng_cmd = 'yum'
         pkg_mng_opts = '-y'
         pkg_mng_subcommand_opts = ''
+        pkg_mng_install_opts = ''
 
     for cpack in rpm:
         pkg = None
@@ -145,20 +147,22 @@ def _update_package_list_and_install(ctx, remote, rpm, config):
                       'sudo', pkg_mng_cmd, pkg_mng_opts, 'remove',
                       pkg_mng_subcommand_opts, pkg, run.Raw(';'),
                       'sudo', pkg_mng_cmd, pkg_mng_opts, 'install',
-                      pkg_mng_subcommand_opts, pkg, run.Raw(';'),
+                      pkg_mng_subcommand_opts, pkg_mng_install_opts,
+                      pkg, run.Raw(';'),
                       'fi']
             )
         if pkg is None:
             remote.run(args=[
                 'sudo', pkg_mng_cmd, pkg_mng_opts, 'install',
-                pkg_mng_subcommand_opts, cpack
+                pkg_mng_subcommand_opts, pkg_mng_install_opts, cpack
             ])
         else:
             remote.run(
                 args=['if', 'test', run.Raw('!'), '-e',
                       run.Raw(pkg), run.Raw(';'), 'then',
                       'sudo', pkg_mng_cmd, pkg_mng_opts, 'install',
-                      pkg_mng_subcommand_opts, cpack, run.Raw(';'),
+                      pkg_mng_subcommand_opts, pkg_mng_install_opts,
+                      cpack, run.Raw(';'),
                       'fi'])
 
 
@@ -316,10 +320,13 @@ def _upgrade_packages(ctx, config, remote, pkgs):
     if builder.dist_release in ['opensuse', 'sle']:
         pkg_mng_opts = '-n'
         pkg_mng_subcommand_opts = '--capability'
+        pkg_mng_install_opts = '--no-recommends'
     else:
         pkg_mng_opts = '-y'
         pkg_mng_subcommand_opts = ''
+        pkg_mng_install_opts = ''
     args = ['sudo', pkg_mng_cmd, pkg_mng_opts,
-            'install', pkg_mng_subcommand_opts]
+            'install', pkg_mng_subcommand_opts,
+            pkg_mng_install_opts]
     args += pkgs
     remote.run(args=args)


### PR DESCRIPTION
Since teuthology is used to automate CI testing, it is undesirable to
install anything more than is necessary to run the tests.

Fixes: #84
Signed-off-by: Nathan Cutler <ncutler@suse.com>