### PR TITLE
salt: implement locking mechanism around salt-master restart

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 boto==2.39.0
 cffi==1.5.2
 cliff==2.2.0
+fasteners=0.14.1
 keystoneauth1==2.12.1
 openstacksdk==0.9.5
 os-client-config==1.21.1


### PR DESCRIPTION
If several ceph-cm-salt jobs run at once, they race to restart the
salt-master.service on the teuthology VM, and unpleasantness ensues.

Fixes: https://github.com/SUSE/teuthology/issues/87
Signed-off-by: Nathan Cutler <ncutler@suse.com>