### PR TITLE
buildpackages: install createrepo package carefully

### DIFF
--- a/teuthology/task/buildpackages/make-rpm.sh
+++ b/teuthology/task/buildpackages/make-rpm.sh
@@ -263,7 +263,8 @@ function build_rpm_repo() {
     local base=$3
 
     if [ "$suse" = true ] ; then
-        sudo zypper -n install createrepo
+        sudo zypper --non-interactive --no-gpg-checks refresh
+        sudo zypper --non-interactive install --no-recommends createrepo
     else
         sudo yum install -y createrepo
     fi


### PR DESCRIPTION
Address error message "Source '...' does not contain the desired medium" when
repos get stale.

Signed-off-by: Nathan Cutler <ncutler@suse.com>