### PR TITLE
requirements.txt: pin version numbers of several modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,12 @@
 -e .
 
 boto==2.39.0
-cffi==1.5.2
+cffi==1.10.0
 cliff==2.2.0
+cryptography==1.9
 fasteners==0.14.1
 keystoneauth1==2.12.1
+idna==2.5
 openstacksdk==0.9.5
 os-client-config==1.21.1
 osc-lib==1.1.0
@@ -14,9 +16,11 @@ oslo.config==3.17.0
 oslo.i18n==3.9.0
 oslo.serialization==2.13.0
 oslo.utils==3.16.0
+pycparser==2.14
 python-cinderclient==1.9.0
 python-glanceclient==2.5.0
 python-keystoneclient==3.5.0
 python-neutronclient==4.1.1
 python-novaclient==6.0.0
 python-openstackclient==3.2.0
+requests==2.18.1


### PR DESCRIPTION
The requests and cryptography modules got updated, giving rise
to several conflicts with ceph-workbench, which pins the versions
of its dependencies.

Signed-off-by: Nathan Cutler <ncutler@suse.com>