### PR TITLE
openstack: install gcc on every SUSE test node

### DIFF
--- a/teuthology/openstack/openstack-opensuse-42.2-user-data.txt
+++ b/teuthology/openstack/openstack-opensuse-42.2-user-data.txt
@@ -20,7 +20,7 @@ runcmd:
  - zypper --non-interactive --no-gpg-checks refresh
  - zypper --non-interactive remove systemd-logger
  - zypper --non-interactive install --no-recommends python wget git ntp rsyslog
-   lsb-release salt-minion salt-master make
+   lsb-release salt-minion salt-master make gcc gcc-c++
  - sed -i -e "s/^#master:.*$/master:\ $(curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//')$(eval printf "%03d%03d%03d%03d.{lab_domain}" $(echo "{nameserver}" | tr . ' '))/" /etc/salt/minion
  - ( if ! grep '^server' /etc/ntp.conf ; then for i in 0 1 2 3 ; do echo "server $i.opensuse.pool.ntp.org iburst" >> /etc/ntp.conf ; done ; fi )
  - systemctl enable salt-minion.service ntpd.service

--- a/teuthology/openstack/openstack-opensuse-42.3-user-data.txt
+++ b/teuthology/openstack/openstack-opensuse-42.3-user-data.txt
@@ -19,7 +19,7 @@ runcmd:
  - 'zypper rr openSUSE-Leap-Cloud-Tools || :'
  - zypper --non-interactive --no-gpg-checks refresh
  - zypper --non-interactive remove systemd-logger
- - zypper --non-interactive install --no-recommends python wget git ntp rsyslog lsb-release make
+ - zypper --non-interactive install --no-recommends python wget git ntp rsyslog lsb-release make gcc gcc-c++
  - sed -i -e "s/^#master:.*$/master:\ $(curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//')$(eval printf "%03d%03d%03d%03d.{lab_domain}" $(echo "{nameserver}" | tr . ' '))/" /etc/salt/minion
  - ( if ! grep '^server' /etc/ntp.conf ; then for i in 0 1 2 3 ; do echo "server $i.opensuse.pool.ntp.org iburst" >> /etc/ntp.conf ; done ; fi )
  - systemctl enable ntpd.service

--- a/teuthology/openstack/openstack-sle-12.2-user-data.txt
+++ b/teuthology/openstack/openstack-sle-12.2-user-data.txt
@@ -19,7 +19,7 @@ runcmd:
  - ( MYHOME=/home/{username} ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /root/.ssh/authorized_keys $MYHOME/.ssh ; chown -R {username}.users $MYHOME/.ssh )
  - zypper --non-interactive --no-gpg-checks refresh
  - zypper --non-interactive install --no-recommends python wget git ntp rsyslog
-   lsb-release salt-minion salt-master make
+   lsb-release salt-minion salt-master make gcc gcc-c++
  - sed -i -e "s/^#master:.*$/master:\ $(curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//')$(eval printf "%03d%03d%03d%03d.{lab_domain}" $(echo "{nameserver}" | tr . ' '))/" /etc/salt/minion
  - ( if ! grep '^server' /etc/ntp.conf ; then for i in 0 1 2 3 ; do echo "server $i.opensuse.pool.ntp.org iburst" >> /etc/ntp.conf ; done ; fi )
  - systemctl enable salt-minion.service ntpd.service


### PR DESCRIPTION
gcc is needed to run certain test scripts in qa/workunits/

Signed-off-by: Nathan Cutler <ncutler@suse.com>