### PR TITLE
Disable GPG checks in the install task

### DIFF
--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -794,7 +794,9 @@ class GitbuilderProject(object):
             url = "{base_url}/{arch}".format(
                 base_url=self.base_url, arch=self.arch)
             self.remote.run(args=[
-                'sudo', 'zypper', '-n', 'addrepo', '-p', '1', url, 'ceph-rpm-under-test'
+                'sudo', 'zypper', '-n', 'addrepo', '-p', '1', url, 'ceph-rpm-under-test',
+                Raw(';'),
+                'sudo', 'zypper', '-n', '--no-gpg-checks', 'refresh'
             ])
         else:
             self.remote.run(args=['sudo', 'yum', '-y', 'install', url])

--- a/teuthology/task/install/rpm.py
+++ b/teuthology/task/install/rpm.py
@@ -125,12 +125,14 @@ def _update_package_list_and_install(ctx, remote, rpm, config):
 
     if dist_release in ['opensuse', 'sle']:
         pkg_mng_cmd = 'zypper'
-        pkg_mng_opts = '-n --no-gpg-checks'
+        pkg_mng_opts = '-n'
+        pkg_mng_gpg_opt = '--no-gpg-checks'
         pkg_mng_subcommand_opts = '--capability'
         pkg_mng_install_opts = '--no-recommends'
     else:
         pkg_mng_cmd = 'yum'
         pkg_mng_opts = '-y'
+        pkg_mng_gpg_opt = ''
         pkg_mng_subcommand_opts = ''
         pkg_mng_install_opts = ''
 
@@ -146,14 +148,14 @@ def _update_package_list_and_install(ctx, remote, rpm, config):
                       run.Raw(pkg), run.Raw(';'), 'then',
                       'sudo', pkg_mng_cmd, pkg_mng_opts, 'remove',
                       pkg_mng_subcommand_opts, pkg, run.Raw(';'),
-                      'sudo', pkg_mng_cmd, pkg_mng_opts, 'install',
+                      'sudo', pkg_mng_cmd, pkg_mng_opts, pkg_mng_gpg_opt, 'install',
                       pkg_mng_subcommand_opts, pkg_mng_install_opts,
                       pkg, run.Raw(';'),
                       'fi']
             )
         if pkg is None:
             remote.run(args=[
-                'sudo', pkg_mng_cmd, pkg_mng_opts, 'install',
+                'sudo', pkg_mng_cmd, pkg_mng_opts, pkg_mng_gpg_opt, 'install',
                 pkg_mng_subcommand_opts, pkg_mng_install_opts, cpack
             ])
         else:

--- a/teuthology/task/install/rpm.py
+++ b/teuthology/task/install/rpm.py
@@ -26,7 +26,7 @@ def _remove(ctx, config, remote, rpm):
 
     if dist_release in ['opensuse', 'sle']:
         pkg_mng_cmd = 'zypper'
-        pkg_mng_opts = '-n'
+        pkg_mng_opts = '-n --no-gpg-checks'
         pkg_mng_subcommand_opts = '--capability'
     else:
         pkg_mng_cmd = 'yum'
@@ -125,7 +125,7 @@ def _update_package_list_and_install(ctx, remote, rpm, config):
 
     if dist_release in ['opensuse', 'sle']:
         pkg_mng_cmd = 'zypper'
-        pkg_mng_opts = '-n'
+        pkg_mng_opts = '-n --no-gpg-checks'
         pkg_mng_subcommand_opts = '--capability'
         pkg_mng_install_opts = '--no-recommends'
     else:


### PR DESCRIPTION
Also refresh zypper metadata cache immediately after adding new repo.

Later, when the install task starts to use real RPMs/repos (e.g. from OBS), I will need to add some logic to not pass `--no-gpg-checks` if using "real" repos.