### PR TITLE
Fix SLE15 user-data scripts

### DIFF
--- a/teuthology/openstack/openstack-sle-15.0-user-data.txt
+++ b/teuthology/openstack/openstack-sle-15.0-user-data.txt
@@ -15,7 +15,7 @@ users:
     sudo: ["ALL=(ALL) NOPASSWD:ALL"]
     groups: users
 runcmd:
- - ( MYHOME=/home/{username} ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /home/sles/.ssh/authorized_keys $MYHOME/.ssh ; chown -R {username}.users $MYHOME/.ssh )
+ - ( MYHOME=/home/{username} ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /root/.ssh/authorized_keys $MYHOME/.ssh ; chown -R {username}.users $MYHOME/.ssh )
  - zypper --non-interactive --no-gpg-checks refresh
  - zypper --non-interactive install --no-recommends wget rsyslog lsb-release make gcc gcc-c++
  - sed -i -e "s/^#master:.*$/master:\ $(curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//')$(eval printf "%03d%03d%03d%03d.{lab_domain}" $(echo "{nameserver}" | tr . ' '))/" /etc/salt/minion

--- a/teuthology/provision/openstack.py
+++ b/teuthology/provision/openstack.py
@@ -54,6 +54,8 @@ class ProvisionOpenStack(OpenStack):
             username=self.username,
             lab_domain=config.lab_domain)
         open(self.user_data, 'w').write(user_data)
+        log.debug("user_data file contents:")
+        log.debug(user_data)
 
     def attach_volumes(self, name, volumes):
         """

--- a/teuthology/task/buildpackages/sle-15.0-user-data.txt
+++ b/teuthology/task/buildpackages/sle-15.0-user-data.txt
@@ -9,6 +9,6 @@ users:
     sudo: ["ALL=(ALL) NOPASSWD:ALL"]
     groups: users
 runcmd:
- - ( MYHOME=/home/ubuntu ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /home/sles/.ssh/authorized_keys $MYHOME/.ssh ; chown -R ubuntu.users $MYHOME/.ssh )
+ - ( MYHOME=/home/ubuntu ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /root/.ssh/authorized_keys $MYHOME/.ssh ; chown -R ubuntu.users $MYHOME/.ssh )
  - zypper --non-interactive install --no-recommends wget git-core rsyslog lsb-release
 final_message: "READYTORUN"


### PR DESCRIPTION
The image generation script is overriding the disable_root setting in
/etc/cloud/cloud.cfg. As a result, openstack seeds the key in
/root/.ssh/authorized_keys instead of /home/sles/.ssh/authorized_keys

The problem was, our user-data was copying /home/sles/.ssh/authorized_keys - 
as a result, teuthology could not SSH in.
