### PR TITLE
[DNM] Add --run-name option

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -80,7 +80,7 @@ Linux)
 	fi
 	;;
     opensuse*|suse|sles)
-        for package in gcc libmysqld-devel zlib-devel python-pip python-devel python-virtualenv libev-devel libmysqlclient-devel libffi-devel; do
+        for package in gcc zlib-devel python-pip python-devel python-virtualenv libev-devel libmysqlclient-devel libffi-devel; do
             if [ "$(rpm -q $package)" == "package $package is not installed" ]; then
                 if [ "$(rpm -q --whatprovides $package)" == "no package provides $package" ]; then
                     missing="${missing:+$missing }$package"

--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -38,6 +38,11 @@ def get_suite_parser():
         help='Do a dry run; do not schedule anything',
     )
     parser.add_argument(
+        '--run-name',
+        help=('Override run name; can be used with external CI systems'
+              ' to easy result reference.'),
+    )
+    parser.add_argument(
         '-s', '--suite',
         help='The suite to schedule',
     )

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -31,6 +31,8 @@ Standard arguments:
   -s <suite>, --suite <suite>
                               The suite to schedule
   --wait                      Block until the suite is finished
+  --run-name <run_name>       Optional argument used to override name
+                              of the run.
   -c <ceph>, --ceph <ceph>    The ceph branch to run against
                               [default: {default_ceph_branch}]
   -S <sha1>, --sha1 <sha1>    The ceph sha1 to run against (overrides -c)

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -36,7 +36,7 @@ class Run(object):
         args must be a config.YamlConfig object
         """
         self.args = args
-        self.name = self.make_run_name()
+        self.name = self.args.run_name or self.make_run_name()
 
         if self.args.ceph_repo:
             config.ceph_git_url = self.args.ceph_repo


### PR DESCRIPTION
It is usefull to have possibility to assign custom run name.
First of all, if teuthology run is scheduled from external
continuous integration system it makes it easy to refer
to corresponding job.

Second, it solves the problem when several different runs
are scheduled at the same time, which allows to avoid jobs
get into different run.