### PR TITLE
Add new openSUSE Leap ID for os-release

### DIFF
--- a/teuthology/orchestra/opsys.py
+++ b/teuthology/orchestra/opsys.py
@@ -142,6 +142,8 @@ class OS(object):
         name = cls._get_value(str_, 'ID').lower()
         if name == 'sles':
             name = 'sle'
+        elif name == 'opensuse-leap'):
+            name = 'opensuse'
         version = cls._get_value(str_, 'VERSION_ID')
         obj = cls(name=name, version=version)
 


### PR DESCRIPTION
Treat 'opensuse-leap' as equivalent to 'opensuse'