### PR TITLE
Dockerfile v1 based on opensuse:42.3 and not using virtualenv.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM opensuse:42.3
+
+SHELL ["/bin/bash", "-c"]
+RUN zypper -n install python-devel python-pip libmysqlclient-devel git-core gcc glibc-devel
+RUN pip install --upgrade pip
+RUN mkdir /app
+RUN git clone https://github.com/SUSE/teuthology.git /app
+WORKDIR /app
+RUN pip install --user --no-cache-dir -r requirements.txt
+ENV PATH "$PATH:/root/.local/bin"
+RUN teuthology-openstack --help
+ENTRYPOINT /bin/bash

--- a/docker/README.txt
+++ b/docker/README.txt
@@ -1,0 +1,21 @@
+Build:
+
+`sudo docker build -t teuthology_leap .`
+
+Use:
+We can pass openrc.sh args as env-file after some modifications:
+https://docs.docker.com/edge/engine/reference/commandline/run/#set-environment-variables--e---env---env-file
+
+`sed 's/export //g' ../ovh-openrc.sh | tee ovh.list` # also remove `unset` vars
+
+To use your hosts ssh-key you can run it like:
+
+`docker run -v ~/.ssh:/root/.ssh:ro --env-file ../ovh.list  --rm -it teuthology_leap`
+
+This will place you in the running container;
+Inside the container run:
+
+# eval $(ssh-agent -s)
+# ssh-add /root/.ssh/id_rsa
+
+Execute your teuthology-openstack commands (if required modify the ssh key filenames)


### PR DESCRIPTION
Build:
`sudo docker build -t teuthology_leap .`

Use:
We can pass openrc.sh args as env-file after some modifications:
https://docs.docker.com/edge/engine/reference/commandline/run/#set-environment-variables--e---env---env-file

`sed 's/export //g' ../ovh-openrc.sh | tee ovh.list` # also remove `unset` vars

`docker run --env-file ../ovh.list  --rm -it teuthology_leap`

Execute your commands.

Signed-off-by: Shyukri Shyukriev <shshyukriev@suse.com>