### PR TITLE
Fix cannot populate paddles

### DIFF
--- a/teuthology/openstack/openstack-user-data.txt
+++ b/teuthology/openstack/openstack-user-data.txt
@@ -14,5 +14,9 @@ runcmd:
  - su - -c '(set -x ; CLONE_OPENSTACK && cd teuthology && ./bootstrap install)' TEUTHOLOGY_USERNAME >> /tmp/init.out 2>&1
  - echo 'export OPENRC' | tee /home/TEUTHOLOGY_USERNAME/openrc.sh
  - su - -c '(set -x ; source openrc.sh ; cd teuthology ; source virtualenv/bin/activate ; teuthology/openstack/setup-openstack.sh --nworkers NWORKERS UPLOAD CEPH_WORKBENCH CANONICAL_TAGS SETUP_OPTIONS)' TEUTHOLOGY_USERNAME >> /tmp/init.out 2>&1
- - /etc/init.d/teuthology restart
+ # wa: we want to stop paddles and pulpito started by setup-openstack, before start teuthology service
+ - pkill -f 'pecan serve'
+ - pkill -f 'python run.py'
+ - systemctl enable teuthology
+ - systemctl start teuthology
 final_message: "teuthology is up and running after $UPTIME seconds"

--- a/teuthology/openstack/setup-openstack.sh
+++ b/teuthology/openstack/setup-openstack.sh
@@ -700,13 +700,14 @@ function main() {
     #
     # assume the first available IPv4 subnet is going to be used to assign IP to the instance
     #
-    local default_subnets=$(neutron subnet-list -f json -c cidr -c ip_version | jq '.[] | select(.ip_version == 4) | .cidr')
-    if test -n "$default_subnets" ; then
-        for subnet in $default_subnets ; do
-            eval subnet=$subnet # get rid of surrounding ""
-            subnets="$subnets $subnet"
-        done
-    fi
+    [ -z network ] && {
+        local default_subnets=$(openstack subnet list --ip-version 4 -f json | jq -r '.[] | .Subnet' | sort | uniq)
+    } || {
+        local network_id=$(openstack network list -f json | jq -r ".[] | select(.Name == \"$network\") | .ID")
+        local default_subnets=$(openstack subnet list --ip-version 4 -f json \
+            | jq -r ".[] | select(.Network == \"$network_id\") | .Subnet" | sort | uniq)
+    }
+    subnets=$(echo $subnets $default_subnets)
 
     case $provider in
         entercloudsuite)


### PR DESCRIPTION
When trying to deploy teuthology on openstack with several networks
and non unique subnet addresses setup-openstack script fails to add
nodes to paddles databases.

This patch removes duplicates while getting default_subnets.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>