### PR TITLE
suite: Implement --sleep-before-teardown option

### DIFF
--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -177,6 +177,11 @@ def get_suite_parser():
         '--suite-repo',
         help=("Use tasks and suite definition in this repository"),
     )
+    parser.add_argument(
+        '--sleep-before-teardown',
+        help='Number of seconds to sleep before tearing down the target VMs',
+        default=0
+    )
     return parser
 
 def get_openstack_parser():

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -71,6 +71,11 @@ Standard arguments:
                               <suite_branch> to be ignored for scheduling
                               purposes, but it will still be used for test
                               running.
+  --sleep-before-teardown <seconds>
+                              Number of seconds to sleep before tearing down
+                              the test cluster(s). Use with care, as this
+                              applies to all jobs in the run.
+                              [default: 0]
 
 Scheduler arguments:
   --owner <owner>             Job owner

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -176,6 +176,7 @@ class TeuthologyConfig(YamlConfig):
                 'size': 1,
             },
         },
+        'sleep_before_teardown': 0,
     }
 
     def __init__(self, yaml_path=None):

--- a/teuthology/run_tasks.py
+++ b/teuthology/run_tasks.py
@@ -59,14 +59,25 @@ def _import(from_package, module_name, task_name):
     return module
 
 
-def run_one_task(taskname, **kwargs):
+def run_one_task(taskname, stack, timer, **kwargs):
+    if 'log_message' in kwargs:
+        log.info(kwargs['log_message'])
+        del(kwargs['log_message'])
+    else:
+        log.info("Running task {}...".format(taskname))
+    timer.mark('%s enter' % taskname)
     taskname = taskname.replace('-', '_')
     task = get_task(taskname)
-    return task(**kwargs)
+    manager = task(**kwargs)
+    if hasattr(manager, '__enter__'):
+        stack.append((taskname, manager))
+        manager.__enter__()
 
 
 def run_tasks(tasks, ctx):
     archive_path = ctx.config.get('archive_path')
+    sleep_before_teardown = ctx.config.get('sleep_before_teardown')
+    sleep_task = { "sleep": { "duration": sleep_before_teardown } }
     if archive_path:
         timer = Timer(
             path=os.path.join(archive_path, 'timing.yaml'),
@@ -81,12 +92,11 @@ def run_tasks(tasks, ctx):
                 ((taskname, config),) = taskdict.iteritems()
             except (ValueError, AttributeError):
                 raise RuntimeError('Invalid task definition: %s' % taskdict)
-            log.info('Running task %s...', taskname)
-            timer.mark('%s enter' % taskname)
-            manager = run_one_task(taskname, ctx=ctx, config=config)
-            if hasattr(manager, '__enter__'):
-                stack.append((taskname, manager))
-                manager.__enter__()
+            run_one_task(taskname, stack, timer, ctx=ctx, config=config)
+        if sleep_before_teardown:
+            ((taskname, config),) = sleep_task.iteritems()
+            run_one_task(taskname, stack, timer, ctx=ctx, config=config,
+                log_message='Running sleep task because --sleep-before-teardown was given...')
     except BaseException as e:
         if isinstance(e, ConnectionLostError):
             # Prevent connection issues being flagged as failures
@@ -139,6 +149,10 @@ def run_tasks(tasks, ctx):
             from .task import interactive
             log.warning('Saw failure during task execution, going into interactive mode...')
             interactive.task(ctx=ctx, config=None)
+        if sleep_before_teardown:
+            ((taskname, config),) = sleep_task.iteritems()
+            run_one_task(taskname, stack, timer, ctx=ctx, config=config,
+                log_message='Running sleep task because --sleep-before-teardown was given...')
         # Throughout teuthology, (x,) = y has been used to assign values
         # from yaml files where only one entry of type y is correct.  This
         # causes failures with 'too many values to unpack.'  We want to

--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -93,6 +93,7 @@ dict_templ = {
         }
     },
     'repo': Placeholder('ceph_repo'),
+    'sleep_before_teardown': 0,
     'suite': Placeholder('suite'),
     'suite_repo': Placeholder('suite_repo'),
     'suite_relpath': Placeholder('suite_relpath'),

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -273,6 +273,8 @@ class Run(object):
             job_config.email = self.args.email
         if self.args.owner:
             job_config.owner = self.args.owner
+        if self.args.sleep_before_teardown:
+            job_config.sleep_before_teardown = int(self.args.sleep_before_teardown)
         return job_config
 
     def build_base_args(self):

--- a/teuthology/task/dump_ctx.py
+++ b/teuthology/task/dump_ctx.py
@@ -1,0 +1,15 @@
+import logging
+import pprint
+
+log = logging.getLogger(__name__)
+pp = pprint.PrettyPrinter(indent=4)
+
+def _pprint_me(thing, prefix):
+    return prefix + "\n" + pp.pformat(thing)
+
+def task(ctx, config):
+    """
+    Dump job context and config in teuthology log/output
+    """
+    log.info(_pprint_me(ctx, "Job context:"))
+    log.info(_pprint_me(config, "Job config:"))

--- a/teuthology/task/print.py
+++ b/teuthology/task/print.py
@@ -1,5 +1,16 @@
 """
 Print task
+
+A task that simply prints the output that is given to it as
+an argument. Can be used like any other task (under sequential,
+etc...)
+
+i.e.:
+
+tasks:
+- print: "String"
+- chef: null
+- print: "Another String"
 """
 
 import logging

--- a/teuthology/task/sleep.py
+++ b/teuthology/task/sleep.py
@@ -28,5 +28,5 @@ def task(ctx, config):
         config = {}
     assert isinstance(config, dict)
     duration = int(config.get('duration', 5))
-    log.info('Sleeping for %d', duration)
+    log.info('Sleeping for {} seconds'.format(duration))
     time.sleep(duration)


### PR DESCRIPTION
With this option, all jobs in the run sleep for the given number of seconds as
the very last thing they do, regardless of success or failure.
    
Use case: interactive debugging
