### PR TITLE
openstack: use ssh identity as key_filename by default

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -682,7 +682,13 @@ class TeuthologyOpenStack(OpenStack):
         self.setup_logs()
         set_config_attr(self.args)
         log.debug('Teuthology config: %s' % self.config.openstack)
-        self.key_filename = self.args.key_filename
+        for keyfile in [self.args.key_filename,
+                        os.environ['HOME'] + '/.ssh/id_rsa',
+                        os.environ['HOME'] + '/.ssh/id_dsa',
+                        os.environ['HOME'] + '/.ssh/id_ecdsa']:
+            if (keyfile and os.path.isfile(keyfile)):
+                self.key_filename = keyfile
+                break
         if not self.key_filename:
             raise Exception('No key file provided, please, use --key-filename option')
         self.verify_openstack()


### PR DESCRIPTION
Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>
(cherry picked from commit 1017722ab3044bbcc208f3e22369e583c61f4e92)