### PR TITLE
setup.py: do not try to install MySQL-python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ setup(
     ],
     install_requires=['setuptools',
                       'gevent',
-                      # For teuthology-coverage
-                      'MySQL-python == 1.2.3',
+                      ## For teuthology-coverage
+                      #'MySQL-python == 1.2.3',
                       'PyYAML',
                       'argparse >= 1.2.1',
                       'beanstalkc >= 0.2.0',


### PR DESCRIPTION
This module is a royal PITA to install in openSUSE Leap 15.0,
causing headaches for teuthology newbies.

Also, we do not use teuthology-coverage for anything, so just
comment it out.

Signed-off-by: Nathan Cutler <ncutler@suse.com>