### PR TITLE
Fix ovh paddles populate

### DIFF
--- a/teuthology/openstack/setup-openstack.sh
+++ b/teuthology/openstack/setup-openstack.sh
@@ -700,7 +700,7 @@ function main() {
     #
     # assume the first available IPv4 subnet is going to be used to assign IP to the instance
     #
-    [ -z network ] && {
+    [ -z "$network" ] && {
         local default_subnets=$(openstack subnet list --ip-version 4 -f json | jq -r '.[] | .Subnet' | sort | uniq)
     } || {
         local network_id=$(openstack network list -f json | jq -r ".[] | select(.Name == \"$network\") | .ID")


### PR DESCRIPTION
Unfortunate typo instroduced in sha1 e491969d4b5b9dca710d1ce89f0cde918bbee1b4
which fixed ECP nodes creation and broke OVH nodes creation.