### PR TITLE
task/install: allow ceph-test to be installed with vendor change

### DIFF
--- a/teuthology/task/install/rpm.py
+++ b/teuthology/task/install/rpm.py
@@ -139,7 +139,11 @@ def _update_package_list_and_install(ctx, remote, rpm, config):
 
     if not install_packages:
         log.info("install_packages set to False: not installing Ceph packages")
-        rpm = ["ceph-test"]
+        # Although "librados2" is an indirect dependency of ceph-test, we
+        # install it separately because, otherwise, ceph-test cannot be
+        # installed (even with --force) when there are several conflicting
+        # repos from different vendors.
+        rpm = ["librados2", "ceph-test"]
 
     # rpm does not force installation of a particular version of the project
     # packages, so we can put extra_system_packages together with the rest
@@ -176,7 +180,9 @@ def _update_package_list_and_install(ctx, remote, rpm, config):
     if dist_release in ['opensuse', 'sle']:
         pkg_mng_cmd = 'zypper'
         pkg_mng_opts = ['--non-interactive', '--no-gpg-checks']
-        pkg_mng_install_opts = ['--capability', '--no-recommends']
+        # NOTE: --capability contradicts --force
+        #pkg_mng_install_opts = ['--capability', '--no-recommends']
+        pkg_mng_install_opts = ['--force', '--no-recommends']
         pkg_mng_remove_opts = '--capability'
     else:
         pkg_mng_cmd = 'yum'

--- a/teuthology/task/install/util.py
+++ b/teuthology/task/install/util.py
@@ -9,6 +9,13 @@ from teuthology.orchestra import run
 log = logging.getLogger(__name__)
 
 
+def _flat2gen(alist):
+    for item in alist:
+        if isinstance(item, list):
+            for subitem in item: yield subitem
+        else:
+            yield item
+
 def _get_builder_project(ctx, remote, config):
     return packaging.get_builder_project()(
         config.get('project', 'ceph'),


### PR DESCRIPTION
Fixes:

```
2018-10-11T10:16:53.414 INFO:teuthology.orchestra.run.target217182141091.stdout:Problem: ceph-test-12.2.8+git.1536505967.080f2248ff-2.17.2.x86_64 requires librbd.so.1()(64bit), but this requirement cannot be provided
2018-10-11T10:16:53.414 INFO:teuthology.orchestra.run.target217182141091.stdout:  uninstallable providers: librbd1-12.1.0+git.1498654198.20d6a47cc9-1.4.x86_64[base_repo5]
2018-10-11T10:16:53.414 INFO:teuthology.orchestra.run.target217182141091.stdout:                   librbd1-12.2.8+git.1536505967.080f2248ff-2.17.2.x86_64[ceph_repo5]
2018-10-11T10:16:53.414 INFO:teuthology.orchestra.run.target217182141091.stdout:                   librbd1-12.2.7+git.1531910353.c0ef85b854-2.12.1.x86_64[update_repo5]
2018-10-11T10:16:53.414 INFO:teuthology.orchestra.run.target217182141091.stdout: Solution 1: install librados2-12.2.8+git.1536505967.080f2248ff-2.17.2.x86_64 (with vendor change)
2018-10-11T10:16:53.415 INFO:teuthology.orchestra.run.target217182141091.stdout:  SUSE LLC <https://www.suse.com/>  -->  obs://build.suse.de/Devel:Storage:5.0
2018-10-11T10:16:53.415 INFO:teuthology.orchestra.run.target217182141091.stdout: Solution 2: do not ask to install a solvable providing ceph-test
2018-10-11T10:16:53.415 INFO:teuthology.orchestra.run.target217182141091.stdout: Solution 3: break ceph-test-12.2.8+git.1536505967.080f2248ff-2.17.2.x86_64 by ignoring some of its dependencies
2018-10-11T10:16:53.415 INFO:teuthology.orchestra.run.target217182141091.stdout:
2018-10-11T10:16:53.415 INFO:teuthology.orchestra.run.target217182141091.stdout:Choose from above solutions by number or cancel [1/2/3/c] (c): c
```