### PR TITLE
Add optional priority for --test-repo

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -804,9 +804,15 @@ class TeuthologyOpenStack(OpenStack):
             else:
                 argv.append(original_argv.pop(0))
         if self.args.test_repo:
-            repos = [{'name':k, 'url': v}
-                                    for k, v in [x.split(':', 1)
-                                    for x in self.args.test_repo]]
+            def repo(name, url):
+                if '!' in name:
+                    n, p = name.split('!', 1)
+                    return {'name': n, 'priority': int(p), 'url': url}
+                else:
+                    return {'name': name, 'url': url}
+            repos = [repo(k, v)
+                     for k, v in [x.split(':', 1)
+                     for x in self.args.test_repo]]
             log.info("Using repos: %s" % self.args.test_repo)
 
             overrides = {

--- a/teuthology/task/install/rpm.py
+++ b/teuthology/task/install/rpm.py
@@ -86,10 +86,16 @@ def _zypper_addrepo(remote, repo_list):
     :return:
     """
     for repo in repo_list:
-        remote.run(args=[
-            'sudo', 'zypper', '-n', 'addrepo', '--refresh', '--no-gpgcheck',
-            '-p', '1', repo['url'], repo['name'],
-        ])
+        if 'priority' in repo:
+            remote.run(args=[
+                'sudo', 'zypper', '-n', 'addrepo', '--refresh', '--no-gpgcheck',
+                '-p', str(repo['priority']), repo['url'], repo['name'],
+            ])
+        else:
+            remote.run(args=[
+                'sudo', 'zypper', '-n', 'addrepo', '--refresh', '--no-gpgcheck',
+                repo['url'], repo['name'],
+            ])
 
 def _zypper_removerepo(remote, repo_list):
     """


### PR DESCRIPTION
Priority can be set adding optional '!' symbol with a number between
name and url. Internally there will be a 'priority' field added
next to 'name' and 'url' fields to the yaml definition.

Usage examples:
    --test-repo 'first-repo:http://hostname.domain/no-priority/repo'
    --test-repo 'second-repo!99:http://hostname.domain/default-priority/repo'
    --test-repo 'third-repo!1:http://hostname.domain/highest-priority/repo'
    --test-repo 'fourth-repo!2:http://hostname.domain/next-priority/repo'
    --test-repo 'fifth-repo!0:http://hostname.domain/zero-priority/repo'

Notes for zypper:
    The higher the number, the lower the priority.
    No priority is equivalent to 99 or 0 priorities.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>