### PR TITLE
teuthology-openstack: add nameserver option

### DIFF
--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -197,6 +197,10 @@ def get_openstack_parser():
         default='teuthology',
     )
     parser.add_argument(
+        '--nameserver',
+        help='nameserver ip address (optional)',
+    )
+    parser.add_argument(
         '--simultaneous-jobs',
         help='maximum number of jobs running in parallel',
         type=int,

--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -778,6 +778,7 @@ class TeuthologyOpenStack(OpenStack):
         argv = []
         while len(original_argv) > 0:
             if original_argv[0] in ('--name',
+                                    '--nameserver',
                                     '--conf',
                                     '--teuthology-branch',
                                     '--teuthology-git-url',
@@ -1048,6 +1049,9 @@ ssh access           : ssh {identity}{username}@{ip} # logs in /usr/share/nginx/
             all_options += [ '--network ' + network ]
         if self.args.simultaneous_jobs:
             all_options += [ '--nworkers ' + str(self.args.simultaneous_jobs) ]
+        if self.args.nameserver:
+            all_options += [ '--nameserver %s' % self.args.nameserver]
+
 
         cmds = [
             "su - -c '(set -x ; %s && cd teuthology && ./bootstrap install)' "


### PR DESCRIPTION
Add --nameserver option to teuthology-openstack cli tool so
teuthology cluster can be deployed and configured to use
customly provided dns

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.de>