### PR TITLE
teuthology-openstack: do not deploy cluster by default

### DIFF
--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -221,6 +221,11 @@ def get_openstack_parser():
         default=0,
     )
     parser.add_argument(
+        '--setup',
+        action='store_true', default=False,
+        help='deploy the cluster, if it does not exist',
+    )
+    parser.add_argument(
         '--teardown',
         action='store_true', default=None,
         help='destroy the cluster, if it exists',

--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -696,7 +696,8 @@ class TeuthologyOpenStack(OpenStack):
             self.instance = OpenStackInstance(self.server_name())
             self.teardown()
             return 0
-        self.setup()
+        if self.args.setup:
+            self.setup()
         exit_code = 0
         if self.args.suite:
             if self.args.wait:
@@ -794,6 +795,7 @@ class TeuthologyOpenStack(OpenStack):
                                     '--test-repo'):
                 del original_argv[0:2]
             elif original_argv[0] in ('--teardown',
+                                      '--setup',
                                       '--upload',
                                       '--no-canonical-tags'):
                 del original_argv[0]


### PR DESCRIPTION
We do not want to deploy cluster by mistake, so it is
reasonable to have dedicated option for cluster deployment,
like --setup.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.de>