### PR TITLE
teuthology-openstack: add banner after cluster creation

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -887,6 +887,7 @@ ssh access           : ssh {identity}{username}@{ip} # logs in /usr/share/nginx/
             if self.get_provider() != 'rackspace':
                 self.create_security_group()
             self.create_cluster()
+            self.reminders()
 
     def setup_logs(self):
         """


### PR DESCRIPTION
When creating a teuthology openstack cluster and not
requesting any suite suite run the teuthology-openstack
quits silently not giving information where the cluster
is created and how its services can be reached.
This fix addresses the issue above.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.de>