### PR TITLE
openstack: fix pulpito and paddles status in init script

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -1075,7 +1075,12 @@ ssh access           : ssh {identity}{username}@{ip} # logs in /usr/share/nginx/
                 "{user} >> /tmp/init.out "
                 "2>&1".format(user=self.username,
                               opts=' '.join(setup_options + all_options))),
-            "/etc/init.d/teuthology restart"
+            # wa: we want to stop paddles and pulpito started by
+            # setup-openstack before starting teuthology service
+            "pkill -f 'pecan serve'",
+            "pkill -f 'python run.py'",
+            "systemctl enable teuthology",
+            "systemctl start teuthology",
         ]
         if cacert_cmd:
             cmds.insert(0,cmd_str(cacert_cmd))


### PR DESCRIPTION
After deployment teuthology cluster on openstack, teuthology
service status-paddles and status-pulpito commands report
'dead', however paddles and pulpito are running.
This fix addresses this issue.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.de>