### PR TITLE
internal/syslog: whitelist ceph-crash daemon messages

### DIFF
--- a/teuthology/task/internal/syslog.py
+++ b/teuthology/task/internal/syslog.py
@@ -130,6 +130,8 @@ def syslog(ctx, config):
                     run.Raw('|'),
                     'egrep', '-v', '\\bsalt-master\\b|\\bsalt-minion\\b|\\bsalt-api\\b',
                     run.Raw('|'),
+                    'grep', '-v', 'ceph-crash',
+                    run.Raw('|'),
                     'head', '-n', '1',
                 ],
                 stdout=StringIO(),


### PR DESCRIPTION
None of these should cause test failures.

Signed-off-by: Dan Mick <dan.mick@redhat.com>
(cherry picked from commit b81d5f37418fa6a3b5729a42b28b7b48f735b45d)

---

NOTE: this is needed to support Nautilus. See http://10.86.0.135/ubuntu-2018-10-25_13:03:32-deepsea:tier0-ses6---basic-openstack/177/teuthology.log for the type of test failure it prevents.