### PR TITLE
teuthology-openstack: fix broken deployment

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -79,7 +79,7 @@ class OpenStackInstance(object):
             self.set_info()
         else:
             self.info = dict(map(lambda (k,v): (k.lower(), v), info.iteritems()))
-        if self.info['status'] == 'ERROR':
+        if isinstance(self.info, dict) and self.info.get('status', '') == 'ERROR':
             errmsg = 'VM creation failed'
             if 'message' in self.info:
                 errmsg = '{}: {}'.format(errmsg, self.info['message'])


### PR DESCRIPTION
d6be711301fe7331acd428ab261ea648ef86305f broke the t-o deployment,
causing it to fail with the following Traceback:

2018-10-25 17:23:46,078.078 DEBUG:teuthology.misc:No server with a name
or ID of 'teuth-jschmid' exists.
Traceback (most recent call last):
  File "/home/jxs/projects/teuthology/teuthology/v/bin/teuthology-openstack", line 11, in <module>
    load_entry_point('teuthology', 'console_scripts', 'teuthology-openstack')()
  File "/home/jxs/projects/teuthology/teuthology/scripts/openstack.py", line 7, in main
    sys.exit(teuthology.openstack.main(parse_args(argv), argv))
  File "/home/jxs/projects/teuthology/teuthology/teuthology/openstack/__init__.py", line 1310, in main
    return TeuthologyOpenStack(ctx, teuth_config, argv).main()
  File "/home/jxs/projects/teuthology/teuthology/teuthology/openstack/__init__.py", line 704, in main
    self.setup()
  File "/home/jxs/projects/teuthology/teuthology/teuthology/openstack/__init__.py", line 890, in setup
    self.instance = OpenStackInstance(self.server_name())
  File "/home/jxs/projects/teuthology/teuthology/teuthology/openstack/__init__.py", line 82, in __init__
    if self.info['status'] == 'ERROR':
TypeError: 'NoneType' object has no attribute '__getitem__'

Signed-off-by: Joshua Schmid <jschmid@suse.com>
Signed-off-by: Nathan Cutler <ncutler@suse.com>