### PR TITLE
Wrap SSH'ing for teardown in try/except block. This should prevent st…

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -1308,7 +1308,11 @@ openstack security group rule create --protocol udp --src-group {server} --dst-p
         instance_id = self.get_instance_id()
 
         if instance_id:
-            self.ssh("sudo /etc/init.d/teuthology stop || true")
+            try:
+                self.ssh("sudo /etc/init.d/teuthology stop || true")
+            except socket.error as e:
+                log.debug('teardown ssh connect socket.error ' + str(e))
+                continue
             self.delete_floating_ip(instance_id)
         self.run("server delete %s || true" % self.packages_repository())
         self.run("server delete --wait %s || true" % self.server_name())


### PR DESCRIPTION
…ale/broken instances which were deleted via UI and keypair/security groups were not, since the code was unreachable

Signed-off-by: Shyukri Shyukriev <shshyukriev@suse.com>