### PR TITLE
teuthology/task/clock.py: do not fail

### DIFF
--- a/teuthology/task/clock.py
+++ b/teuthology/task/clock.py
@@ -45,6 +45,8 @@ def task(ctx, config):
                 run.Raw(';'),
                 'PATH=/usr/bin:/usr/sbin', 'ntpq', '-p', run.Raw('||'),
                 'PATH=/usr/bin:/usr/sbin', 'chronyc', 'sources',
+                run.Raw('||'),
+                'true'
             ],
         )
 
@@ -58,6 +60,8 @@ def task(ctx, config):
                 args=[
                     'PATH=/usr/bin:/usr/sbin', 'ntpq', '-p', run.Raw('||'),
                     'PATH=/usr/bin:/usr/sbin', 'chronyc', 'sources',
+                    run.Raw('||'),
+                    'true'
                     ],
                 )
 
@@ -76,6 +80,8 @@ def check(ctx, config):
             args=[
                 'PATH=/usr/bin:/usr/sbin', 'ntpq', '-p', run.Raw('||'),
                 'PATH=/usr/bin:/usr/sbin', 'chronyc', 'sources',
+                run.Raw('||'),
+                'true'
                 ],
             )
 
@@ -89,5 +95,7 @@ def check(ctx, config):
                 args=[
                     'PATH=/usr/bin:/usr/sbin', 'ntpq', '-p', run.Raw('||'),
                     'PATH=/usr/bin:/usr/sbin', 'chronyc', 'sources',
+                    run.Raw('||'),
+                    'true'
                     ],
                 )


### PR DESCRIPTION
"chronyc sources" likes to fail, for no good reason, on openSUSE 15.0:

```
2018-11-10T08:59:39.907 INFO:teuthology.orchestra.run.target192168000045:Running: 'sudo systemctl stop ntpd.service || sudo systemctl stop chronyd.service ; sudo ntpd -gq || sudo chronyc makestep ; sudo systemctl start ntpd.service || sudo systemctl start chronyd.service ; PATH=/usr/bin:/usr/sbin ntpq -p || PATH=/usr/bin:/usr/sbin chronyc sources'
2018-11-10T08:59:40.022 INFO:teuthology.orchestra.run.target192168000045.stderr:Failed to stop ntpd.service: Unit ntpd.service not loaded.
2018-11-10T08:59:40.124 INFO:teuthology.orchestra.run.target192168000045.stderr:sudo: ntpd: command not found
2018-11-10T08:59:40.172 INFO:teuthology.orchestra.run.target192168000045.stdout:506 Cannot talk to daemon
2018-11-10T08:59:40.230 INFO:teuthology.orchestra.run.target192168000045.stderr:Failed to start ntpd.service: Unit ntpd.service not found.
2018-11-10T08:59:40.317 INFO:teuthology.orchestra.run.target192168000045.stderr:bash: ntpq: command not found
2018-11-10T08:59:42.035 INFO:teuthology.orchestra.run.target192168000045.stdout:210 Number of sources = 8
2018-11-10T08:59:42.036 INFO:teuthology.orchestra.run.target192168000045.stdout:MS Name/IP address         Stratum Poll Reach LastRx Last sample
2018-11-10T08:59:42.036 INFO:teuthology.orchestra.run.target192168000045.stdout:===============================================================================
2018-11-10T08:59:42.036 INFO:teuthology.orchestra.run.target192168000045.stdout:^? services.quadranet.com        0   6     0     -     +0ns[   +0ns] +/-    0ns
2018-11-10T08:59:42.037 INFO:teuthology.orchestra.run.target192168000045.stdout:^? 69.36.182.57.west-datace>     0   6     0     -     +0ns[   +0ns] +/-    0ns
2018-11-10T08:59:42.037 INFO:teuthology.orchestra.run.target192168000045.stdout:^? rolex.netservicesgroup.c>     0   6     0     -     +0ns[   +0ns] +/-    0ns
2018-11-10T08:59:42.037 INFO:teuthology.orchestra.run.target192168000045.stdout:^? clock.xmission.com            0   6     0     -     +0ns[   +0ns] +/-    0ns
2018-11-10T08:59:42.037 INFO:teuthology.orchestra.run.target192168000045.stdout:^? ha82.smatwebdesign.com        0   6     0     -     +0ns[   +0ns] +/-    0ns
2018-11-10T08:59:42.038 INFO:teuthology.orchestra.run.target192168000045.stdout:^? hydrogen.constant.com         0   6     0     -     +0ns[   +0ns] +/-    0ns
2018-11-10T08:59:42.038 INFO:teuthology.orchestra.run.target192168000045.stdout:^? 2607:fcd0:0:a::50             0   6     0     -     +0ns[   +0ns] +/-    0ns
2018-11-10T08:59:42.038 INFO:teuthology.orchestra.run.target192168000045.stdout:503 No such source
2018-11-10T08:59:42.040 ERROR:teuthology.run_tasks:Saw exception from tasks.
Traceback (most recent call last):
  File "/home/ubuntu/teuthology/teuthology/run_tasks.py", line 95, in run_tasks
    run_one_task(taskname, stack, timer, ctx=ctx, config=config)
  File "/home/ubuntu/teuthology/teuthology/run_tasks.py", line 74, in run_one_task
    manager.__enter__()
  File "/usr/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/home/ubuntu/teuthology/teuthology/task/clock.py", line 47, in task
    'PATH=/usr/bin:/usr/sbin', 'chronyc', 'sources',
  File "/home/ubuntu/teuthology/teuthology/orchestra/remote.py", line 210, in run
    r = self._runner(client=self.ssh, name=self.shortname, **kwargs)
  File "/home/ubuntu/teuthology/teuthology/orchestra/run.py", line 403, in run
    r.wait()
  File "/home/ubuntu/teuthology/teuthology/orchestra/run.py", line 166, in wait
    label=self.label)
CommandFailedError: Command failed on target192168000045 with status 1: 'sudo systemctl stop ntpd.service || sudo systemctl stop chronyd.service ; sudo ntpd -gq || sudo chronyc makestep ; sudo systemctl start ntpd.service || sudo systemctl start chronyd.service ; PATH=/usr/bin:/usr/sbin ntpq -p || PATH=/usr/bin:/usr/sbin chronyc sources'
```