### PR TITLE
user-data: update openSUSE 15.0 user-data

### DIFF
--- a/teuthology/openstack/openstack-opensuse-15.0-user-data.txt
+++ b/teuthology/openstack/openstack-opensuse-15.0-user-data.txt
@@ -16,11 +16,9 @@ users:
     groups: users
 runcmd:
  - ( MYHOME=/home/{username} ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /root/.ssh/authorized_keys $MYHOME/.ssh ; chown -R {username}.users $MYHOME/.ssh )
- - zypper --non-interactive addrepo https://download.opensuse.org/repositories/filesystems:/ceph:/mimic/openSUSE_Leap_15.0/filesystems:ceph:mimic.repo
  - zypper --non-interactive --gpg-auto-import-keys refresh
- - zypper --non-interactive remove librados2 librbd1 multipath-tools-rbd qemu-block-rbd
- - zypper --non-interactive install --no-recommends wget git-core rsyslog lsb-release make gcc gcc-c++ salt-master salt-minion salt-api chrony
- - sed -i -e 's/^! pool/pool/' /etc/chrony.conf
+ - zypper --non-interactive remove --force librados2 librbd1 multipath-tools-rbd qemu-block-rbd ntp
+ - zypper --non-interactive install --no-recommends --force wget git-core rsyslog lsb-release make gcc gcc-c++ salt-master salt-minion salt-api chrony
  - systemctl enable chronyd.service
  - systemctl start chronyd.service
  - sed -i -e "s/^#master:.*$/master:\ $(curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//')$(eval printf "%03d%03d%03d%03d.{lab_domain}" $(echo "{nameserver}" | tr . ' '))/" /etc/salt/minion


### PR DESCRIPTION
With these changes, it once again becomes possible to run jobs on openSUSE 15.0.

Signed-off-by: Nathan Cutler <ncutler@suse.com>