### PR TITLE
DNM Archive custom artifacts after job complete

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -229,6 +229,7 @@ def get_initial_tasks(lock, config, machine_type):
     if 'roles' in config:
         init_tasks.extend([
             {'internal.archive': None},
+            {'internal.archive_artifacts': None},
             {'internal.coredump': None},
             {'internal.sudo': None},
             {'internal.syslog': None},

--- a/teuthology/task/install/__init__.py
+++ b/teuthology/task/install/__init__.py
@@ -135,6 +135,8 @@ def remove_packages(ctx, config, pkgs):
     with parallel() as p:
         for remote in ctx.cluster.remotes.iterkeys():
             system_type = teuthology.get_system_type(remote)
+            if remote.os.name in ['opensuse', 'sle']:
+                remote.run(args='zypper lr')
             p.spawn(remove_pkgs[
                     system_type], ctx, config, remote, pkgs[system_type])
 


### PR DESCRIPTION
Example:

    override:
        archive_artifacts:
        - '/etc/zypp/repos.d'
        - '/etc/resolv.conf'
        - name: 'zypper-repos'
          exec: 'sudo zypper lr'
        - name: 'nslookup-suse.com'
          exec: 'nslookup suse.com 2>&1'