### PR TITLE
config: use lower default RAM hint for openstack provisioning

### DIFF
--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -168,7 +168,7 @@ class TeuthologyConfig(YamlConfig):
             'ip': '1.1.1.1',
             'machine': {
                 'disk': 20,
-                'ram': 8000,
+                'ram': 4000,
                 'cpus': 1,
             },
             'volumes': {

--- a/teuthology/openstack/setup-openstack.sh
+++ b/teuthology/openstack/setup-openstack.sh
@@ -94,7 +94,7 @@ openstack:
   #
   machine:
     disk: 20 # GB
-    ram: 8000 # MB
+    ram: 4000 # MB
     cpus: 1
   volumes:
     count: 0


### PR DESCRIPTION
Fixes: https://trello.com/c/X5StTYxZ/378-teuthology-runs-in-ecp-use-needlessly-large-flavor
Related-to: https://github.com/SUSE/ceph/pull/253
Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

- [ ] https://github.com/SUSE/ceph/pull/253 merged
- [ ] https://github.com/SUSE/ceph/pull/253 backported to ses5