### PR TITLE
orchestra: fix no connection after reboot

### DIFF
--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -199,14 +199,10 @@ class Remote(object):
 
         TODO refactor to move run.run here?
         """
-        if self.ssh is None:
-            self.reconnect(timeout=5)
-        if self.ssh:
-            # There is a chance that the ssh(paramiko) instance
-            # is populated but has no transport yet.
-            if self.ssh.get_transport():
-                if not self.ssh.get_transport().is_active():
-                    self.reconnect(timeout=5)
+        if not self.ssh or \
+           not self.ssh.get_transport() or \
+           not self.ssh.get_transport().is_active():
+            self.reconnect()
         r = self._runner(client=self.ssh, name=self.shortname, **kwargs)
         r.remote = self
         return r


### PR DESCRIPTION
This resolves the issue when remote lost connection
if the command was a reboot of the host and there was
only one unsuccessful try to reconnect and as a result
was loosing transport and got stuck with message like:

WARNING:tasks.deepsea.orch:No connection established yet..

Signed-off-by: Kyr <kyrylo.shatskyy@suse.com>