### PR TITLE
Archive job config

### DIFF
--- a/teuthology/test/test_worker.py
+++ b/teuthology/test/test_worker.py
@@ -61,7 +61,7 @@ class TestWorker(object):
     @patch("os.environ")
     @patch("os.mkdir")
     @patch("yaml.safe_dump")
-    @patch("tempfile.NamedTemporaryFile")
+    @patch("__builtin__.open")
     def test_run_job_with_watchdog(self, m_tempfile, m_safe_dump, m_mkdir,
                                    m_environ, m_popen, m_t_config,
                                    m_run_watchdog):
@@ -110,7 +110,7 @@ class TestWorker(object):
     @patch("os.environ")
     @patch("os.mkdir")
     @patch("yaml.safe_dump")
-    @patch("tempfile.NamedTemporaryFile")
+    @patch("__builtin__.open")
     def test_run_job_no_watchdog(self, m_tempfile, m_safe_dump, m_mkdir,
                                  m_environ, m_popen, m_t_config, m_symlink_log,
                                  m_sleep):

--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -259,11 +259,10 @@ def run_job(job_config, teuth_bin_path, archive_dir, verbose):
         arg.extend(['--description', job_config['description']])
     arg.append('--')
 
-    with tempfile.NamedTemporaryFile(prefix='teuthology-worker.',
-                                     suffix='.tmp',) as tmp:
-        yaml.safe_dump(data=job_config, stream=tmp)
-        tmp.flush()
-        arg.append(tmp.name)
+    with open(job_config['archive_path'] + '/job-config.yaml', 'w') as job_config_file:
+        yaml.safe_dump(data=job_config, stream=job_config_file)
+        job_config_file.flush()
+        arg.append(job_config_file.name)
         env = os.environ.copy()
         python_path = env.get('PYTHONPATH', '')
         python_path = ':'.join([suite_path, python_path]).strip(':')


### PR DESCRIPTION
When worker runs teuthology it provides job config as temporary file which will be deleted after job finished. This will save job config in the job log archive directory and is useful when debugging the job.

Signed-off-by: Kyr <kyrylo.shatskyy@suse.com>