### PR TITLE
openstack: take defaults from environment

### DIFF
--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+import os
 
 import teuthology.openstack
 
@@ -43,6 +44,7 @@ def get_suite_parser():
     parser.add_argument(
         '-c', '--ceph',
         help='The ceph branch to run against',
+        default=os.getenv('TEUTH_CEPH_BRANCH', 'master'),
     )
     parser.add_argument(
         '-k', '--kernel',
@@ -62,6 +64,7 @@ def get_suite_parser():
     parser.add_argument(
         '--suite-branch',
         help='Use this suite branch instead of the ceph branch',
+        default=os.getenv('TEUTH_SUITE_BRANCH', 'master'),
     )
     parser.add_argument(
         '-e', '--email',
@@ -172,10 +175,12 @@ def get_suite_parser():
     parser.add_argument(
         '--ceph-repo',
         help=("Query this repository for Ceph branch and SHA1"),
+        default=os.getenv('TEUTH_CEPH_REPO', 'https://github.com/ceph/ceph'),
     )
     parser.add_argument(
         '--suite-repo',
         help=("Use tasks and suite definition in this repository"),
+        default=os.getenv('TEUTH_SUITE_REPO', 'https://github.com/ceph/ceph'),
     )
     parser.add_argument(
         '--sleep-before-teardown',
@@ -237,11 +242,12 @@ def get_openstack_parser():
     parser.add_argument(
         '--teuthology-git-url',
         help="git clone url for teuthology",
+        default=os.getenv('TEUTH_REPO', 'https://github.com/ceph/teuthology'),
     )
     parser.add_argument(
         '--teuthology-branch',
         help="use this teuthology branch instead of master",
-        default='master',
+        default=os.getenv('TEUTH_BRANCH', 'master'),
     )
     parser.add_argument(
         '--ceph-workbench-git-url',

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -2,12 +2,13 @@ import docopt
 import sys
 
 import teuthology.suite
+from teuthology.suite import override_arg_defaults as defaults
 from teuthology.config import config
 
 doc = """
 usage: teuthology-suite --help
-       teuthology-suite [-v | -vv ] --ceph <ceph> --suite <suite> [options] [<config_yaml>...]
-       teuthology-suite [-v | -vv ] --ceph <ceph> --rerun <name>  [options] [<config_yaml>...]
+       teuthology-suite [-v | -vv ] --suite <suite> [options] [<config_yaml>...]
+       teuthology-suite [-v | -vv ] --rerun <name>  [options] [<config_yaml>...]
 
 Run a suite of ceph integration tests. A suite is a directory containing
 facets. A facet is a directory containing config snippets. Running a suite
@@ -31,6 +32,7 @@ Standard arguments:
                               The suite to schedule
   --wait                      Block until the suite is finished
   -c <ceph>, --ceph <ceph>    The ceph branch to run against
+                              [default: {default_ceph_branch}]
   -S <sha1>, --sha1 <sha1>    The ceph sha1 to run against (overrides -c)
                               If both -S and -c are supplied, -S wins, and
                               there is no validation that sha1 is contained
@@ -49,7 +51,7 @@ Standard arguments:
                               [default: basic]
   -t <branch>, --teuthology-branch <branch>
                               The teuthology branch to run against.
-                              [default: master]
+                              [default: {default_teuthology_branch}]
   -m <type>, --machine-type <type>
                               Machine type [default: {default_machine_type}]
   -d <distro>, --distro <distro>
@@ -66,6 +68,7 @@ Standard arguments:
                               [default: qa]
   --suite-branch <suite_branch>
                               Use this suite branch instead of the ceph branch
+                              [default: {default_suite_branch}]
   --suite-dir <suite_dir>     Use this alternative directory as-is when
                               assembling jobs from yaml fragments. This causes
                               <suite_branch> to be ignored for scheduling
@@ -132,8 +135,13 @@ Scheduler arguments:
 """.format(
     default_machine_type=config.default_machine_type,
     default_results_timeout=config.results_timeout,
-    default_ceph_repo=config.get_ceph_git_url(),
-    default_suite_repo=config.get_ceph_qa_suite_git_url(),
+    default_ceph_repo=defaults('--ceph-repo',
+                            config.get_ceph_git_url()),
+    default_suite_repo=defaults('--suite-repo',
+                            config.get_ceph_qa_suite_git_url()),
+    default_ceph_branch=defaults('--ceph-branch', 'master'),
+    default_suite_branch=defaults('--suite-branch', 'master'),
+    default_teuthology_branch=defaults('--teuthology-branch', 'master'),
 )
 
 

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -17,6 +17,25 @@ from .util import schedule_fail
 log = logging.getLogger(__name__)
 
 
+def override_arg_defaults(name, default, env=os.environ):
+    env_arg = {
+        '--ceph-repo'         : 'TEUTH_CEPH_REPO',
+        '--suite-repo'        : 'TEUTH_SUITE_REPO',
+        '--ceph-branch'       : 'TEUTH_CEPH_BRANCH',
+        '--suite-branch'      : 'TEUTH_SUITE_BRANCH',
+        '--teuthology-branch' : 'TEUTH_BRANCH',
+    }
+    if name in env_arg and env_arg[name] in env.keys():
+        variable = env_arg[name]
+        value = env[variable]
+        log.debug("Default value for '{arg}' is overridden "
+                  "from environment with: {val}"
+                  .format(arg=name, val=value))
+        return value
+    else:
+        return default
+
+
 def process_args(args):
     conf = YamlConfig()
     rename_args = {


### PR DESCRIPTION
This patch introduces TEUTH_ based environment variables
which can be used to avoid bulky commands while overiding
default values for some of the teuthology arguments.
Removes mandatory of --ceph option for teuthology-suite,
and defaults to 'master'.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@gmail.com>
(cherry picked from commit f0db3fe73429599345a58485ae7e5f2c4d641a24)

Conflicts:
	scripts/openstack.py
	scripts/suite.py