### PR TITLE
syslog.py: whitelist innocent tcmu-runner log message

### DIFF
--- a/teuthology/task/internal/syslog.py
+++ b/teuthology/task/internal/syslog.py
@@ -132,6 +132,8 @@ def syslog(ctx, config):
                     run.Raw('|'),
                     'grep', '-v', 'ceph-crash',
                     run.Raw('|'),
+                    'egrep', '-v', '\\btcmu-runner\\b.*\\load_our_module\\b',
+                    run.Raw('|'),
                     'head', '-n', '1',
                 ],
                 stdout=StringIO(),


### PR DESCRIPTION
When running the new iSCSI smoke test, tcmu-runner emits a syslog
message that was not whitelisted:

2019-03-27T10:00:17.292154+00:00 target192168000056 tcmu-runner[37366]: 2019-03-27 10:00:17.291 37366 [INFO] load_our_module:537: Inserted module 'target_core_user'

Since the message is at severity level INFO, it was causing teuthology
to raise a red flag.

Signed-off-by: Nathan Cutler <ncutler@suse.com>