### PR TITLE
syslog.py: whitelist INFO-level tcmu-runner syslog messages

### DIFF
--- a/teuthology/task/internal/syslog.py
+++ b/teuthology/task/internal/syslog.py
@@ -132,7 +132,7 @@ def syslog(ctx, config):
                     run.Raw('|'),
                     'grep', '-v', 'ceph-crash',
                     run.Raw('|'),
-                    'egrep', '-v', '\\btcmu-runner\\b.*\\load_our_module\\b',
+                    'egrep', '-v', '\\btcmu-runner\\b.*\\bINFO\\b',
                     run.Raw('|'),
                     'head', '-n', '1',
                 ],


### PR DESCRIPTION
During iSCSI Gateway (igw) test runs, tcmu-runner sometimes emits syslog
messages at INFO level. According to the ceph-iscsi developers, these messages
are harmless and should not cause tests to fail.

Signed-off-by: Nathan Cutler <ncutler@suse.com>