### PR TITLE
openstack: always pass branch and repo parameters

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -830,13 +830,21 @@ class TeuthologyOpenStack(OpenStack):
         running the teuthology cluster.
         """
         original_argv = self.argv[:]
-        argv = []
+        argv = ['--ceph', self.args.ceph,
+                '--ceph-repo', self.args.ceph_repo,
+                '--suite-repo', self.args.suite_repo,
+                '--suite-branch', self.args.suite_branch,
+                ]
         while len(original_argv) > 0:
             if original_argv[0] in ('--name',
                                     '--nameserver',
                                     '--conf',
                                     '--teuthology-branch',
                                     '--teuthology-git-url',
+                                    '--suite-repo',
+                                    '--suite-branch',
+                                    '--ceph-repo',
+                                    '--ceph',
                                     '--ceph-workbench-branch',
                                     '--ceph-workbench-git-url',
                                     '--archive-upload',


### PR DESCRIPTION
We need to always pass the parameters below in order to make it work using
environment variables:
--ceph
--ceph-repo
--suite-repo
--suite-branch
--teuthology-branch

Signed-off-by: gkyratsas <gkyratsas@suse.com>