### PR TITLE
requirements.txt: bump cryptography version to 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 boto==2.39.0
 cffi==1.11.2
 cliff==2.2.0
-cryptography==2.2.1
+cryptography==2.7
 fasteners==0.14.1
 keystoneauth1==2.12.1
 idna==2.6


### PR DESCRIPTION
"./bootstrap" on latest master fails with:

ERROR: paramiko 2.6.0 has requirement cryptography>=2.5, but you'll have
cryptography 2.2.1 which is incompatible.

Signed-off-by: Nathan Cutler <ncutler@suse.com>