### PR TITLE
run.py: automatically run the "clock" task

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -250,11 +250,7 @@ def get_initial_tasks(lock, config, machine_type):
             pass
         else:
             init_tasks.append({'ansible.cephlab': None})
-
-        # upstream changed this to "clock" in f5d9712 but in openstack
-        # we have the ability to sync clocks in the user-data script,
-        # so we are keeping "clock.check" for now
-        init_tasks.append({'clock.check': None})
+        init_tasks.append({'clock': None})
 
     return init_tasks
 


### PR DESCRIPTION
Companion PR to https://github.com/SUSE/ceph/pull/340

(for alignment with upstream)